### PR TITLE
Migrate to @earendil-works scope, peer-dependency contract, and strict TypeScript

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to the `pi-interactive-shell` extension will be documented i
 
 ## [Unreleased]
 
+### Changed
+- Cut over to the current pi package scope: all imports now use `@earendil-works/pi-coding-agent` and `@earendil-works/pi-tui`, and local module specifiers use `.ts` extensions.
+- Declared `@earendil-works/pi-coding-agent`, `@earendil-works/pi-tui`, and `typebox` as peer dependencies with a `*` range, following pi's package contract. `typebox` is no longer a direct dependency because pi resolves all of these through its extension loader aliases.
+- Added `engines.node: >=22.19.0` to match pi's minimum supported Node version.
+- Added strict TypeScript checking (`tsconfig.json`, `npm run typecheck`) and fixed all resulting errors.
+- `ToolParams` is now derived from the typebox schema (`Static<typeof toolParameters>`) instead of a hand-written duplicate; the drift this exposed was fixed by constraining `handsFree.updateMode` to `'on-quiet' | 'interval'` in the schema, so invalid values are rejected at the tool boundary instead of silently misbehaving.
+- Config shortcuts (`focusShortcut`, `spawn.shortcut`) are validated as key identifiers when loading config; invalid shortcuts now warn and fall back to the defaults instead of silently never matching.
+- Compiled monitor config is now a discriminated union on strategy, making `fileWatch` presence impossible to misuse for non-file-watch strategies.
+- `/dismiss` selection no longer treats an unmatched select label as "dismiss all".
+
 ## [0.13.0] - 2026-04-23
 
 ### Changed

--- a/background-widget.ts
+++ b/background-widget.ts
@@ -1,7 +1,7 @@
-import { truncateToWidth, visibleWidth } from "@mariozechner/pi-tui";
-import { formatDuration } from "./types.js";
-import type { ShellSessionManager } from "./session-manager.js";
-import type { InteractiveShellCoordinator } from "./runtime-coordinator.js";
+import { truncateToWidth, visibleWidth } from "@earendil-works/pi-tui";
+import { formatDuration } from "./types.ts";
+import type { ShellSessionManager } from "./session-manager.ts";
+import type { InteractiveShellCoordinator } from "./runtime-coordinator.ts";
 
 export function setupBackgroundWidget(
 	ctx: { ui: { setWidget: Function }; hasUI?: boolean },

--- a/config.ts
+++ b/config.ts
@@ -1,6 +1,6 @@
 import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
-import { getAgentDir } from "@mariozechner/pi-coding-agent";
+import { getAgentDir } from "@earendil-works/pi-coding-agent";
 
 export type SpawnAgent = "pi" | "codex" | "claude" | "cursor";
 

--- a/config.ts
+++ b/config.ts
@@ -1,12 +1,13 @@
 import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import { getAgentDir } from "@earendil-works/pi-coding-agent";
+import type { KeyId } from "@earendil-works/pi-tui";
 
 export type SpawnAgent = "pi" | "codex" | "claude" | "cursor";
 
 export interface SpawnConfig {
 	defaultAgent: SpawnAgent;
-	shortcut: string;
+	shortcut: KeyId;
 	commands: Record<SpawnAgent, string>;
 	defaultArgs: Record<SpawnAgent, string[]>;
 	worktree: boolean;
@@ -17,7 +18,7 @@ export interface InteractiveShellConfig {
 	exitAutoCloseDelay: number;
 	overlayWidthPercent: number;
 	overlayHeightPercent: number;
-	focusShortcut: string;
+	focusShortcut: KeyId;
 	spawn: SpawnConfig;
 	scrollbackLines: number;
 	ansiReemit: boolean;
@@ -117,7 +118,7 @@ export function loadConfig(cwd: string): InteractiveShellConfig {
 		exitAutoCloseDelay: clampInt(merged.exitAutoCloseDelay, DEFAULT_CONFIG.exitAutoCloseDelay, 0, 60),
 		overlayWidthPercent: clampPercent(merged.overlayWidthPercent, DEFAULT_CONFIG.overlayWidthPercent),
 		overlayHeightPercent: clampInt(merged.overlayHeightPercent, DEFAULT_CONFIG.overlayHeightPercent, 20, 90),
-		focusShortcut: resolveShortcut(merged.focusShortcut, DEFAULT_CONFIG.focusShortcut),
+		focusShortcut: resolveKeyId(merged.focusShortcut, DEFAULT_CONFIG.focusShortcut),
 		spawn: mergedSpawn,
 		scrollbackLines: clampInt(merged.scrollbackLines, DEFAULT_CONFIG.scrollbackLines, 200, 50000),
 		ansiReemit: merged.ansiReemit !== false,
@@ -190,10 +191,10 @@ function mergeSpawnConfig(globalValue: unknown, projectValue: unknown): SpawnCon
 	const projectArgs = isPlainObject(projectSpawn?.defaultArgs) ? projectSpawn.defaultArgs : undefined;
 
 	const mergedCommands = {
-		pi: resolveCommand(projectCommands?.pi ?? globalCommands?.pi, DEFAULT_SPAWN_CONFIG.commands.pi),
-		codex: resolveCommand(projectCommands?.codex ?? globalCommands?.codex, DEFAULT_SPAWN_CONFIG.commands.codex),
-		claude: resolveCommand(projectCommands?.claude ?? globalCommands?.claude, DEFAULT_SPAWN_CONFIG.commands.claude),
-		cursor: resolveCommand(projectCommands?.cursor ?? globalCommands?.cursor, DEFAULT_SPAWN_CONFIG.commands.cursor),
+		pi: resolveNonEmptyString(projectCommands?.pi ?? globalCommands?.pi, DEFAULT_SPAWN_CONFIG.commands.pi),
+		codex: resolveNonEmptyString(projectCommands?.codex ?? globalCommands?.codex, DEFAULT_SPAWN_CONFIG.commands.codex),
+		claude: resolveNonEmptyString(projectCommands?.claude ?? globalCommands?.claude, DEFAULT_SPAWN_CONFIG.commands.claude),
+		cursor: resolveNonEmptyString(projectCommands?.cursor ?? globalCommands?.cursor, DEFAULT_SPAWN_CONFIG.commands.cursor),
 	};
 
 	const mergedDefaultArgs = {
@@ -205,7 +206,7 @@ function mergeSpawnConfig(globalValue: unknown, projectValue: unknown): SpawnCon
 
 	return {
 		defaultAgent: resolveSpawnAgent(projectSpawn?.defaultAgent ?? globalSpawn?.defaultAgent, DEFAULT_SPAWN_CONFIG.defaultAgent),
-		shortcut: resolveShortcut(projectSpawn?.shortcut ?? globalSpawn?.shortcut, DEFAULT_SPAWN_CONFIG.shortcut),
+		shortcut: resolveKeyId(projectSpawn?.shortcut ?? globalSpawn?.shortcut, DEFAULT_SPAWN_CONFIG.shortcut),
 		commands: mergedCommands,
 		defaultArgs: mergedDefaultArgs,
 		worktree: resolveBoolean(projectSpawn?.worktree ?? globalSpawn?.worktree, DEFAULT_SPAWN_CONFIG.worktree),
@@ -219,10 +220,6 @@ function isPlainObject(value: unknown): value is Record<string, unknown> {
 
 function resolveSpawnAgent(value: unknown, fallback: SpawnAgent): SpawnAgent {
 	return value === "pi" || value === "codex" || value === "claude" || value === "cursor" ? value : fallback;
-}
-
-function resolveCommand(value: unknown, fallback: string): string {
-	return resolveShortcut(typeof value === "string" ? value : undefined, fallback);
 }
 
 function resolveStringArray(value: unknown, fallback: string[]): string[] {
@@ -251,8 +248,39 @@ function clampInt(value: number | undefined, fallback: number, min: number, max:
 	return Math.min(max, Math.max(min, rounded));
 }
 
-function resolveShortcut(value: string | undefined, fallback: string): string {
+function resolveNonEmptyString(value: unknown, fallback: string): string {
 	if (typeof value !== "string") return fallback;
 	const trimmed = value.trim();
 	return trimmed.length > 0 ? trimmed : fallback;
+}
+
+const KEY_MODIFIERS = new Set(["ctrl", "shift", "alt", "super"]);
+const KEY_SYMBOLS = "`-=[]\\;',./!@#$%^&*()_+|~{}:<>?";
+const KEY_SPECIALS = new Set([
+	"escape", "esc", "enter", "return", "tab", "space", "backspace", "delete", "insert", "clear",
+	"home", "end", "pageUp", "pageDown", "up", "down", "left", "right",
+	"f1", "f2", "f3", "f4", "f5", "f6", "f7", "f8", "f9", "f10", "f11", "f12",
+]);
+
+function isKeyId(value: string): value is KeyId {
+	const parts = value.split("+");
+	let base = parts.pop() ?? "";
+	if (base === "") {
+		// A trailing "+" means the base key is the "+" symbol itself (e.g. "ctrl++").
+		if (parts.pop() !== "") return false;
+		base = "+";
+	}
+	if (parts.some((mod) => !KEY_MODIFIERS.has(mod))) return false;
+	if (new Set(parts).size !== parts.length) return false;
+	if (base.length === 1) return /[a-z0-9]/.test(base) || KEY_SYMBOLS.includes(base);
+	return KEY_SPECIALS.has(base);
+}
+
+function resolveKeyId(value: unknown, fallback: KeyId): KeyId {
+	if (typeof value !== "string") return fallback;
+	const trimmed = value.trim();
+	if (trimmed.length === 0) return fallback;
+	if (isKeyId(trimmed)) return trimmed;
+	console.error(`pi-interactive-shell: invalid shortcut "${trimmed}" in config, using "${fallback}"`);
+	return fallback;
 }

--- a/handoff-utils.ts
+++ b/handoff-utils.ts
@@ -1,9 +1,9 @@
 import { mkdirSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
-import { getAgentDir } from "@mariozechner/pi-coding-agent";
-import type { InteractiveShellConfig } from "./config.js";
-import type { InteractiveShellOptions, InteractiveShellResult } from "./types.js";
-import type { PtyTerminalSession } from "./pty-session.js";
+import { getAgentDir } from "@earendil-works/pi-coding-agent";
+import type { InteractiveShellConfig } from "./config.ts";
+import type { InteractiveShellOptions, InteractiveShellResult } from "./types.ts";
+import type { PtyTerminalSession } from "./pty-session.ts";
 
 export function captureCompletionOutput(
 	session: PtyTerminalSession,

--- a/headless-monitor.ts
+++ b/headless-monitor.ts
@@ -1,6 +1,6 @@
 import { stripVTControlCharacters } from "node:util";
-import type { PtyTerminalSession } from "./pty-session.js";
-import type { InteractiveShellConfig } from "./config.js";
+import type { PtyTerminalSession } from "./pty-session.ts";
+import type { InteractiveShellConfig } from "./config.ts";
 
 export interface MonitorMatchInfo {
 	strategy: "stream" | "poll-diff" | "file-watch";

--- a/index.ts
+++ b/index.ts
@@ -1,4 +1,4 @@
-import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
+import type { AgentToolResult, ExtensionAPI, ExtensionContext, ExtensionUIContext } from "@earendil-works/pi-coding-agent";
 import { isKeyRelease, isKeyRepeat, matchesKey } from "@earendil-works/pi-tui";
 import { InteractiveShellOverlay } from "./overlay-component.ts";
 import { ReattachOverlay } from "./reattach-overlay.ts";
@@ -36,6 +36,9 @@ import { spawn as spawnChildProcess } from "node:child_process";
 
 const coordinator = new InteractiveShellCoordinator();
 const SIDE_CHAT_SHORTCUT = "alt+/";
+
+/** Overlay options for ctx.ui.custom, derived from pi so width/anchor stay in sync with the host. */
+type CustomUiOptions = NonNullable<Parameters<ExtensionUIContext["custom"]>[1]>;
 
 function scheduleMonitorHistoryCleanup(sessionId: string, delayMs = 5 * 60 * 1000): void {
 	const attempt = () => {
@@ -109,19 +112,22 @@ function makeStructuredMonitorCompletionCallback(
 	};
 }
 
-type CompiledMonitorConfig = {
+type CompiledMonitorBase = {
 	runtime: MonitorRuntimeConfig;
 	persistence: {
 		stopAfterFirstEvent: boolean;
 		maxEvents?: number;
 	};
-	fileWatch?: Required<MonitorFileWatchConfig>;
 	detector?: {
 		detectorCommand: string;
 		timeoutMs: number;
 	};
 	publicConfig: MonitorConfig;
 };
+
+type CompiledMonitorConfig =
+	| (CompiledMonitorBase & { strategy: "file-watch"; fileWatch: Required<MonitorFileWatchConfig> })
+	| (CompiledMonitorBase & { strategy: "stream" | "poll-diff"; fileWatch?: undefined });
 
 type DetectorDecision = {
 	emit: boolean;
@@ -319,30 +325,7 @@ function compileMonitorConfig(raw: MonitorConfig | undefined):
 		compiledTriggers.push(compiled.compiled);
 	}
 
-	let fileWatch: Required<MonitorFileWatchConfig> | undefined;
-	if (strategy === "file-watch") {
-		if (!raw.fileWatch) {
-			return { ok: false, error: "monitor.fileWatch is required when monitor.strategy='file-watch'." };
-		}
-		const watchPath = raw.fileWatch.path?.trim();
-		if (!watchPath) {
-			return { ok: false, error: "monitor.fileWatch.path must be a non-empty string." };
-		}
-		const watchEvents = raw.fileWatch.events ?? ["rename", "change"];
-		if (!Array.isArray(watchEvents) || watchEvents.length === 0) {
-			return { ok: false, error: "monitor.fileWatch.events must contain at least one event." };
-		}
-		for (const eventName of watchEvents) {
-			if (eventName !== "rename" && eventName !== "change") {
-				return { ok: false, error: `Unsupported monitor.fileWatch event: ${String(eventName)}. Use 'rename' or 'change'.` };
-			}
-		}
-		fileWatch = {
-			path: watchPath,
-			recursive: raw.fileWatch.recursive === true,
-			events: Array.from(new Set(watchEvents)),
-		};
-	} else if (raw.fileWatch) {
+	if (strategy !== "file-watch" && raw.fileWatch) {
 		return { ok: false, error: "monitor.fileWatch is only valid when monitor.strategy='file-watch'." };
 	}
 
@@ -368,10 +351,17 @@ function compileMonitorConfig(raw: MonitorConfig | undefined):
 		}
 		: undefined;
 
+	const runtime: MonitorRuntimeConfig = {
+		strategy,
+		triggers: compiledTriggers,
+		pollIntervalMs,
+		dedupeExactLine,
+		cooldownMs,
+	};
+	const persistence = { stopAfterFirstEvent, maxEvents };
 	const publicConfig: MonitorConfig = {
 		strategy,
 		triggers: raw.triggers,
-		fileWatch,
 		poll: strategy === "poll-diff" ? { intervalMs: pollIntervalMs } : undefined,
 		persistence: {
 			stopAfterFirstEvent,
@@ -389,25 +379,35 @@ function compileMonitorConfig(raw: MonitorConfig | undefined):
 			: undefined,
 	};
 
-	return {
-		ok: true,
-		compiled: {
-			runtime: {
-				strategy,
-				triggers: compiledTriggers,
-				pollIntervalMs,
-				dedupeExactLine,
-				cooldownMs,
-			},
-			persistence: {
-				stopAfterFirstEvent,
-				maxEvents,
-			},
-			fileWatch,
-			detector,
-			publicConfig,
-		},
-	};
+	if (strategy === "file-watch") {
+		if (!raw.fileWatch) {
+			return { ok: false, error: "monitor.fileWatch is required when monitor.strategy='file-watch'." };
+		}
+		const watchPath = raw.fileWatch.path?.trim();
+		if (!watchPath) {
+			return { ok: false, error: "monitor.fileWatch.path must be a non-empty string." };
+		}
+		const watchEvents = raw.fileWatch.events ?? ["rename", "change"];
+		if (!Array.isArray(watchEvents) || watchEvents.length === 0) {
+			return { ok: false, error: "monitor.fileWatch.events must contain at least one event." };
+		}
+		for (const eventName of watchEvents) {
+			if (eventName !== "rename" && eventName !== "change") {
+				return { ok: false, error: `Unsupported monitor.fileWatch event: ${String(eventName)}. Use 'rename' or 'change'.` };
+			}
+		}
+		const fileWatch: Required<MonitorFileWatchConfig> = {
+			path: watchPath,
+			recursive: raw.fileWatch.recursive === true,
+			events: Array.from(new Set(watchEvents)),
+		};
+		return {
+			ok: true,
+			compiled: { strategy, fileWatch, runtime, persistence, detector, publicConfig: { ...publicConfig, fileWatch } },
+		};
+	}
+
+	return { ok: true, compiled: { strategy, runtime, persistence, detector, publicConfig } };
 }
 
 async function runDetectorCommand(
@@ -664,7 +664,7 @@ export default function interactiveShellExtension(pi: ExtensionAPI) {
 		coordinator.clearMonitorEvents(id);
 		sessionManager.unregisterActive(id, false);
 	};
-	const createOverlayUiOptions = (config: InteractiveShellConfig) => ({
+	const createOverlayUiOptions = (config: InteractiveShellConfig): CustomUiOptions => ({
 		overlay: true,
 		overlayOptions: {
 			width: `${config.overlayWidthPercent}%`,
@@ -729,7 +729,7 @@ export default function interactiveShellExtension(pi: ExtensionAPI) {
 		timeout?: number;
 		monitor?: ToolParams["monitor"];
 		onUpdate?: (update: { content: Array<{ type: "text"; text: string }>; details: Record<string, unknown> }) => void;
-	}): Promise<{ content: Array<{ type: "text"; text: string }>; details?: any; isError?: boolean }> => {
+	}): Promise<{ content: Array<{ type: "text"; text: string }>; details?: unknown; isError?: boolean }> => {
 		const { ctx, command, spawn, cwd, name, reason, mode, background, handsFree, handoffPreview, handoffSnapshot, timeout, monitor, onUpdate } = params;
 		const allowsGeneratedCommand = mode === "monitor" && monitor?.strategy === "file-watch";
 		if (!command && !spawn && !allowsGeneratedCommand) {
@@ -789,14 +789,6 @@ export default function interactiveShellExtension(pi: ExtensionAPI) {
 			spawnAgent = resolvedSpawn.spawn.agent;
 			spawnMode = resolvedSpawn.spawn.mode;
 		}
-		const expectsGeneratedCommand = isMonitorMode && monitor?.strategy === "file-watch";
-		if (!effectiveCommand && !expectsGeneratedCommand) {
-			return {
-				content: [{ type: "text", text: "Failed to resolve the command to launch." }],
-				isError: true,
-			};
-		}
-
 		if (isMonitorMode) {
 			const compiledMonitor = compileMonitorConfig(monitor);
 			if (!compiledMonitor.ok) {
@@ -805,48 +797,66 @@ export default function interactiveShellExtension(pi: ExtensionAPI) {
 					isError: true,
 				};
 			}
+			const compiled = compiledMonitor.compiled;
+
+			let sessionCommand: string;
+			let monitorCommand: string;
+			if (compiled.strategy === "file-watch") {
+				sessionCommand = `file-watch ${compiled.fileWatch.path}`;
+				monitorCommand = buildFileWatchCommand(compiled.fileWatch);
+			} else if (!effectiveCommand) {
+				return {
+					content: [{ type: "text", text: "Failed to resolve the command to launch." }],
+					isError: true,
+				};
+			} else {
+				sessionCommand = effectiveCommand;
+				monitorCommand = compiled.strategy === "poll-diff"
+					? buildPollDiffLoopCommand(effectiveCommand, compiled.runtime.pollIntervalMs)
+					: effectiveCommand;
+			}
 
 			const id = generateSessionId(name);
-			const sessionCommand = compiledMonitor.compiled.runtime.strategy === "file-watch"
-				? `file-watch ${compiledMonitor.compiled.fileWatch?.path ?? "<unknown>"}`
-				: effectiveCommand!;
-			const monitorCommand = compiledMonitor.compiled.runtime.strategy === "poll-diff"
-				? buildPollDiffLoopCommand(sessionCommand, compiledMonitor.compiled.runtime.pollIntervalMs)
-				: compiledMonitor.compiled.runtime.strategy === "file-watch"
-					? buildFileWatchCommand(compiledMonitor.compiled.fileWatch!)
-					: sessionCommand;
 			const session = new PtyTerminalSession(
 				{ command: monitorCommand, cwd: effectiveCwd, cols: 120, rows: 40, scrollback: config.scrollbackLines },
 			);
 			const startTime = Date.now();
 			sessionManager.add(sessionCommand, session, name, effectiveReason, { id, noAutoCleanup: true, startedAt: new Date(startTime) });
 
-			coordinator.registerMonitorSession(id, compiledMonitor.compiled.publicConfig, new Date(startTime));
+			coordinator.registerMonitorSession(id, compiled.publicConfig, new Date(startTime));
 			const monitorRunner = new HeadlessDispatchMonitor(session, config, {
 				autoExitOnQuiet: handsFree?.autoExitOnQuiet === true,
 				quietThreshold: handsFree?.quietThreshold ?? config.handsFreeQuietThreshold,
 				gracePeriod: handsFree?.gracePeriod ?? config.autoExitGracePeriod,
 				timeout,
 				startedAt: startTime,
-				monitor: compiledMonitor.compiled.runtime,
-				onMonitorEvent: makeMonitorEventCallback(pi, id, compiledMonitor.compiled, effectiveCwd),
+				monitor: compiled.runtime,
+				onMonitorEvent: makeMonitorEventCallback(pi, id, compiled, effectiveCwd),
 			}, makeStructuredMonitorCompletionCallback(pi, id));
 			registerHeadlessActive(id, sessionCommand, effectiveReason, session, monitorRunner, startTime, config, "monitoring");
 
 			return {
-				content: [{ type: "text", text: appendWorktreeNotice(`Monitor started in background (id: ${id}).\nStrategy: ${compiledMonitor.compiled.publicConfig.strategy ?? "stream"}\nTriggers: ${compiledMonitor.compiled.publicConfig.triggers.map((trigger) => trigger.id).join(", ")}\nYou'll be notified when a trigger emits an event.`, spawnWorktreePath) }],
-				details: { sessionId: id, backgroundId: id, mode: "monitor", monitor: compiledMonitor.compiled.publicConfig, background: true, spawnAgent, spawnMode, spawnWorktreePath },
+				content: [{ type: "text", text: appendWorktreeNotice(`Monitor started in background (id: ${id}).\nStrategy: ${compiled.publicConfig.strategy ?? "stream"}\nTriggers: ${compiled.publicConfig.triggers.map((trigger) => trigger.id).join(", ")}\nYou'll be notified when a trigger emits an event.`, spawnWorktreePath) }],
+				details: { sessionId: id, backgroundId: id, mode: "monitor", monitor: compiled.publicConfig, background: true, spawnAgent, spawnMode, spawnWorktreePath },
 			};
 		}
+
+		if (!effectiveCommand) {
+			return {
+				content: [{ type: "text", text: "Failed to resolve the command to launch." }],
+				isError: true,
+			};
+		}
+		const launchCommand = effectiveCommand;
 
 		if (mode === "dispatch" && background) {
 			const id = generateSessionId(name);
 			const session = new PtyTerminalSession(
-				{ command: effectiveCommand, cwd: effectiveCwd, cols: 120, rows: 40, scrollback: config.scrollbackLines },
+				{ command: launchCommand, cwd: effectiveCwd, cols: 120, rows: 40, scrollback: config.scrollbackLines },
 			);
 
 			const startTime = Date.now();
-			sessionManager.add(effectiveCommand, session, name, effectiveReason, { id, noAutoCleanup: true, startedAt: new Date(startTime) });
+			sessionManager.add(launchCommand, session, name, effectiveReason, { id, noAutoCleanup: true, startedAt: new Date(startTime) });
 
 			const monitor = new HeadlessDispatchMonitor(session, config, {
 				autoExitOnQuiet: handsFree?.autoExitOnQuiet !== false,
@@ -855,7 +865,7 @@ export default function interactiveShellExtension(pi: ExtensionAPI) {
 				timeout,
 				startedAt: startTime,
 			}, makeMonitorCompletionCallback(pi, id, startTime));
-			registerHeadlessActive(id, effectiveCommand, effectiveReason, session, monitor, startTime, config);
+			registerHeadlessActive(id, launchCommand, effectiveReason, session, monitor, startTime, config);
 
 			return {
 				content: [{ type: "text", text: appendWorktreeNotice(`Session dispatched in background (id: ${id}).\nYou'll be notified when it completes. User can /attach ${id} to watch.`, spawnWorktreePath) }],
@@ -879,7 +889,7 @@ export default function interactiveShellExtension(pi: ExtensionAPI) {
 				overlayPromise = ctx.ui.custom<InteractiveShellResult>(
 					(tui, theme, _kb, done) =>
 						new InteractiveShellOverlay(tui, theme, {
-							command: effectiveCommand,
+							command: launchCommand,
 							cwd: effectiveCwd,
 							name,
 							reason: effectiveReason,
@@ -917,7 +927,7 @@ export default function interactiveShellExtension(pi: ExtensionAPI) {
 			setupDispatchCompletion(pi, overlayPromise, config, {
 				id: generatedSessionId,
 				mode,
-				command: effectiveCommand,
+				command: launchCommand,
 				reason: effectiveReason,
 				timeout,
 				handsFree,
@@ -927,12 +937,12 @@ export default function interactiveShellExtension(pi: ExtensionAPI) {
 			if (mode === "dispatch") {
 				return {
 					content: [{ type: "text", text: appendWorktreeNotice(`Session dispatched (id: ${generatedSessionId}).\nYou'll be notified when it completes.\nYou can still query with interactive_shell({ sessionId: "${generatedSessionId}" }) if needed.`, spawnWorktreePath) }],
-					details: { sessionId: generatedSessionId, status: "running", command: effectiveCommand, reason: effectiveReason, mode, spawnAgent, spawnMode, spawnWorktreePath },
+					details: { sessionId: generatedSessionId, status: "running", command: launchCommand, reason: effectiveReason, mode, spawnAgent, spawnMode, spawnWorktreePath },
 				};
 			}
 			return {
-				content: [{ type: "text", text: appendWorktreeNotice(`Session started: ${generatedSessionId}\nCommand: ${effectiveCommand}\n\nUse interactive_shell({ sessionId: "${generatedSessionId}" }) to check status/output.\nUse interactive_shell({ sessionId: "${generatedSessionId}", kill: true }) to end when done.`, spawnWorktreePath) }],
-				details: { sessionId: generatedSessionId, status: "running", command: effectiveCommand, reason: effectiveReason, spawnAgent, spawnMode, spawnWorktreePath },
+				content: [{ type: "text", text: appendWorktreeNotice(`Session started: ${generatedSessionId}\nCommand: ${launchCommand}\n\nUse interactive_shell({ sessionId: "${generatedSessionId}" }) to check status/output.\nUse interactive_shell({ sessionId: "${generatedSessionId}", kill: true }) to end when done.`, spawnWorktreePath) }],
+				details: { sessionId: generatedSessionId, status: "running", command: launchCommand, reason: effectiveReason, spawnAgent, spawnMode, spawnWorktreePath },
 			};
 		}
 
@@ -944,7 +954,7 @@ export default function interactiveShellExtension(pi: ExtensionAPI) {
 			};
 		}
 		onUpdate?.({
-			content: [{ type: "text", text: appendWorktreeNotice(`Opening: ${effectiveCommand}`, spawnWorktreePath) }],
+			content: [{ type: "text", text: appendWorktreeNotice(`Opening: ${launchCommand}`, spawnWorktreePath) }],
 			details: { exitCode: null, backgrounded: false, cancelled: false },
 		});
 
@@ -953,7 +963,7 @@ export default function interactiveShellExtension(pi: ExtensionAPI) {
 			result = await ctx.ui.custom<InteractiveShellResult>(
 				(tui, theme, _kb, done) =>
 					new InteractiveShellOverlay(tui, theme, {
-						command: effectiveCommand,
+						command: launchCommand,
 						cwd: effectiveCwd,
 						name,
 						reason: effectiveReason,
@@ -1022,7 +1032,7 @@ export default function interactiveShellExtension(pi: ExtensionAPI) {
 		}
 
 		return {
-			content: [{ type: "text", text: appendWorktreeNotice(summarizeInteractiveResult(effectiveCommand, result, timeout, effectiveReason), spawnWorktreePath) }],
+			content: [{ type: "text", text: appendWorktreeNotice(summarizeInteractiveResult(launchCommand, result, timeout, effectiveReason), spawnWorktreePath) }],
 			details: { ...result, spawnAgent, spawnMode, spawnWorktreePath },
 		};
 	};
@@ -1078,6 +1088,17 @@ export default function interactiveShellExtension(pi: ExtensionAPI) {
 		parameters: toolParameters,
 
 		async execute(_toolCallId, params, _signal, onUpdate, ctx) {
+			const result = await runTool(params, onUpdate, ctx);
+			// AgentToolResult requires `details`; normalize the paths that produce none.
+			return { content: result.content, details: result.details ?? {}, isError: result.isError };
+		},
+	});
+
+	async function runTool(
+		params: ToolParams,
+		onUpdate: ((update: { content: Array<{ type: "text"; text: string }>; details: Record<string, unknown> }) => void) | undefined,
+		ctx: ExtensionContext,
+	): Promise<{ content: Array<{ type: "text"; text: string }>; details?: unknown; isError?: boolean }> {
 			const {
 				command,
 				spawn,
@@ -1114,7 +1135,7 @@ export default function interactiveShellExtension(pi: ExtensionAPI) {
 				handoffSnapshot,
 				timeout,
 				monitor,
-			} = params as ToolParams;
+			} = params;
 
 			const hasStructuredInput = inputKeys?.length || inputHex?.length || inputPaste;
 			const effectiveInput = hasStructuredInput
@@ -1625,8 +1646,7 @@ export default function interactiveShellExtension(pi: ExtensionAPI) {
 				timeout,
 				onUpdate,
 			});
-		},
-	});
+	}
 
 	pi.registerCommand("spawn", {
 		description: "Spawn the configured default agent, pi, codex, claude, or cursor in an interactive shell overlay",
@@ -1768,18 +1788,21 @@ export default function interactiveShellExtension(pi: ExtensionAPI) {
 			} else if (sessions.length === 1) {
 				targetIds = [sessions[0].id];
 			} else {
-				const options = [
-					{ label: "All sessions" },
-					...sessions.map((s) => {
-						const status = s.session.exited ? "exited" : "running";
-						const duration = formatDuration(Date.now() - s.startedAt.getTime());
-						return { id: s.id, label: `${s.id} (${status}, ${duration})` };
-					}),
-				];
-				const choice = await ctx.ui.select("Dismiss sessions", options.map((o) => o.label));
+				const allLabel = "All sessions";
+				const sessionOptions = sessions.map((s) => {
+					const status = s.session.exited ? "exited" : "running";
+					const duration = formatDuration(Date.now() - s.startedAt.getTime());
+					return { id: s.id, label: `${s.id} (${status}, ${duration})` };
+				});
+				const choice = await ctx.ui.select("Dismiss sessions", [allLabel, ...sessionOptions.map((o) => o.label)]);
 				if (!choice) return;
-				const selected = options.find((o) => o.label === choice);
-				targetIds = selected?.id ? [selected.id] : sessions.map((s) => s.id);
+				if (choice === allLabel) {
+					targetIds = sessions.map((s) => s.id);
+				} else {
+					const selected = sessionOptions.find((o) => o.label === choice);
+					if (!selected) return;
+					targetIds = [selected.id];
+				}
 			}
 
 			for (const tid of targetIds) {

--- a/index.ts
+++ b/index.ts
@@ -1,9 +1,9 @@
-import type { ExtensionAPI, ExtensionContext } from "@mariozechner/pi-coding-agent";
-import { isKeyRelease, isKeyRepeat, matchesKey } from "@mariozechner/pi-tui";
-import { InteractiveShellOverlay } from "./overlay-component.js";
-import { ReattachOverlay } from "./reattach-overlay.js";
-import { PtyTerminalSession } from "./pty-session.js";
-import { formatDuration, formatDurationMs } from "./types.js";
+import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
+import { isKeyRelease, isKeyRepeat, matchesKey } from "@earendil-works/pi-tui";
+import { InteractiveShellOverlay } from "./overlay-component.ts";
+import { ReattachOverlay } from "./reattach-overlay.ts";
+import { PtyTerminalSession } from "./pty-session.ts";
+import { formatDuration, formatDurationMs } from "./types.ts";
 import type {
 	HandsFreeUpdate,
 	InteractiveShellResult,
@@ -14,24 +14,24 @@ import type {
 	MonitorTerminalReason,
 	MonitorThresholdOperator,
 	MonitorTriggerConfig,
-} from "./types.js";
-import { sessionManager, generateSessionId } from "./session-manager.js";
-import { loadConfig } from "./config.js";
-import type { InteractiveShellConfig } from "./config.js";
-import { parseSpawnArgs, resolveSpawn, type SpawnRequest } from "./spawn.js";
-import { translateInput } from "./key-encoding.js";
-import { TOOL_NAME, TOOL_LABEL, TOOL_DESCRIPTION, toolParameters, type ToolParams } from "./tool-schema.js";
-import { HeadlessDispatchMonitor } from "./headless-monitor.js";
+} from "./types.ts";
+import { sessionManager, generateSessionId } from "./session-manager.ts";
+import { loadConfig } from "./config.ts";
+import type { InteractiveShellConfig } from "./config.ts";
+import { parseSpawnArgs, resolveSpawn, type SpawnRequest } from "./spawn.ts";
+import { translateInput } from "./key-encoding.ts";
+import { TOOL_NAME, TOOL_LABEL, TOOL_DESCRIPTION, toolParameters, type ToolParams } from "./tool-schema.ts";
+import { HeadlessDispatchMonitor } from "./headless-monitor.ts";
 import type {
 	HeadlessCompletionInfo,
 	MonitorMatchInfo,
 	MonitorRuntimeConfig,
 	MonitorTriggerMatcher,
-} from "./headless-monitor.js";
-import { setupBackgroundWidget } from "./background-widget.js";
-import { buildDispatchNotification, buildHandsFreeUpdateMessage, buildMonitorEventNotification, buildMonitorLifecycleNotification, buildResultNotification, summarizeInteractiveResult } from "./notification-utils.js";
-import { createSessionQueryState, getSessionOutput } from "./session-query.js";
-import { InteractiveShellCoordinator } from "./runtime-coordinator.js";
+} from "./headless-monitor.ts";
+import { setupBackgroundWidget } from "./background-widget.ts";
+import { buildDispatchNotification, buildHandsFreeUpdateMessage, buildMonitorEventNotification, buildMonitorLifecycleNotification, buildResultNotification, summarizeInteractiveResult } from "./notification-utils.ts";
+import { createSessionQueryState, getSessionOutput } from "./session-query.ts";
+import { InteractiveShellCoordinator } from "./runtime-coordinator.ts";
 import { spawn as spawnChildProcess } from "node:child_process";
 
 const coordinator = new InteractiveShellCoordinator();

--- a/notification-utils.ts
+++ b/notification-utils.ts
@@ -1,6 +1,6 @@
-import type { InteractiveShellResult, HandsFreeUpdate, MonitorEventPayload, MonitorSessionState } from "./types.js";
-import type { HeadlessCompletionInfo } from "./headless-monitor.js";
-import { formatDurationMs } from "./types.js";
+import type { InteractiveShellResult, HandsFreeUpdate, MonitorEventPayload, MonitorSessionState } from "./types.ts";
+import type { HeadlessCompletionInfo } from "./headless-monitor.ts";
+import { formatDurationMs } from "./types.ts";
 
 const BRIEF_TAIL_LINES = 5;
 

--- a/overlay-component.ts
+++ b/overlay-component.ts
@@ -1,10 +1,10 @@
 import { stripVTControlCharacters } from "node:util";
-import type { Component, Focusable, TUI } from "@mariozechner/pi-tui";
-import { matchesKey, truncateToWidth, visibleWidth } from "@mariozechner/pi-tui";
-import type { Theme } from "@mariozechner/pi-coding-agent";
-import { PtyTerminalSession } from "./pty-session.js";
-import { sessionManager, generateSessionId } from "./session-manager.js";
-import type { InteractiveShellConfig } from "./config.js";
+import type { Component, Focusable, TUI } from "@earendil-works/pi-tui";
+import { matchesKey, truncateToWidth, visibleWidth } from "@earendil-works/pi-tui";
+import type { Theme } from "@earendil-works/pi-coding-agent";
+import { PtyTerminalSession } from "./pty-session.ts";
+import { sessionManager, generateSessionId } from "./session-manager.ts";
+import type { InteractiveShellConfig } from "./config.ts";
 import {
 	type InteractiveShellResult,
 	type HandsFreeUpdate,
@@ -15,9 +15,9 @@ import {
 	FOOTER_LINES_COMPACT,
 	formatDuration,
 	formatShortcut,
-} from "./types.js";
-import { captureCompletionOutput, captureTransferOutput, maybeBuildHandoffPreview, maybeWriteHandoffSnapshot } from "./handoff-utils.js";
-import { createSessionQueryState, getSessionOutput } from "./session-query.js";
+} from "./types.ts";
+import { captureCompletionOutput, captureTransferOutput, maybeBuildHandoffPreview, maybeWriteHandoffSnapshot } from "./handoff-utils.ts";
+import { createSessionQueryState, getSessionOutput } from "./session-query.ts";
 
 export class InteractiveShellOverlay implements Component, Focusable {
 	focused = false;

--- a/package.json
+++ b/package.json
@@ -37,11 +37,18 @@
     ],
     "video": "https://github.com/nicobailon/pi-interactive-shell/raw/refs/heads/main/pi-interactive-shell-extension.mp4"
   },
+  "engines": {
+    "node": ">=22.19.0"
+  },
   "dependencies": {
     "@xterm/addon-serialize": "^0.13.0",
     "@xterm/headless": "^5.5.0",
-    "typebox": "^1.1.24",
     "zigpty": "^0.1.6"
+  },
+  "peerDependencies": {
+    "@earendil-works/pi-coding-agent": "*",
+    "@earendil-works/pi-tui": "*",
+    "typebox": "*"
   },
   "scripts": {
     "test": "vitest run"

--- a/package.json
+++ b/package.json
@@ -51,7 +51,8 @@
     "typebox": "*"
   },
   "scripts": {
-    "test": "vitest run"
+    "test": "vitest run",
+    "typecheck": "tsc -p tsconfig.json"
   },
   "keywords": [
     "pi-package",
@@ -78,6 +79,8 @@
   },
   "homepage": "https://github.com/nicobailon/pi-interactive-shell#readme",
   "devDependencies": {
+    "@types/node": "^22.20.1",
+    "typescript": "^5.9.3",
     "vitest": "^3.2.4"
   }
 }

--- a/pty-session.ts
+++ b/pty-session.ts
@@ -3,8 +3,8 @@ import { spawn, type IPty } from "zigpty";
 import type { IBufferCell, Terminal as XtermTerminal } from "@xterm/headless";
 import xterm from "@xterm/headless";
 import { SerializeAddon } from "@xterm/addon-serialize";
-import { sliceLogOutput, trimRawOutput } from "./pty-log.js";
-import { splitAroundDsr, buildCursorPositionResponse } from "./pty-protocol.js";
+import { sliceLogOutput, trimRawOutput } from "./pty-log.ts";
+import { splitAroundDsr, buildCursorPositionResponse } from "./pty-protocol.ts";
 
 const Terminal = xterm.Terminal;
 

--- a/reattach-overlay.ts
+++ b/reattach-overlay.ts
@@ -1,9 +1,9 @@
-import type { Component, Focusable, TUI } from "@mariozechner/pi-tui";
-import { matchesKey, truncateToWidth, visibleWidth } from "@mariozechner/pi-tui";
-import type { Theme } from "@mariozechner/pi-coding-agent";
-import { PtyTerminalSession } from "./pty-session.js";
-import { sessionManager } from "./session-manager.js";
-import type { InteractiveShellConfig } from "./config.js";
+import type { Component, Focusable, TUI } from "@earendil-works/pi-tui";
+import { matchesKey, truncateToWidth, visibleWidth } from "@earendil-works/pi-tui";
+import type { Theme } from "@earendil-works/pi-coding-agent";
+import { PtyTerminalSession } from "./pty-session.ts";
+import { sessionManager } from "./session-manager.ts";
+import type { InteractiveShellConfig } from "./config.ts";
 import {
 	type InteractiveShellResult,
 	type DialogChoice,
@@ -12,8 +12,8 @@ import {
 	FOOTER_LINES_COMPACT,
 	FOOTER_LINES_DIALOG,
 	formatShortcut,
-} from "./types.js";
-import { captureCompletionOutput, captureTransferOutput, maybeBuildHandoffPreview, maybeWriteHandoffSnapshot } from "./handoff-utils.js";
+} from "./types.ts";
+import { captureCompletionOutput, captureTransferOutput, maybeBuildHandoffPreview, maybeWriteHandoffSnapshot } from "./handoff-utils.ts";
 
 export class ReattachOverlay implements Component, Focusable {
 	focused = false;

--- a/runtime-coordinator.ts
+++ b/runtime-coordinator.ts
@@ -1,6 +1,6 @@
-import type { OverlayHandle } from "@mariozechner/pi-tui";
-import type { HeadlessDispatchMonitor } from "./headless-monitor.js";
-import type { MonitorConfig, MonitorEventPayload, MonitorSessionState, MonitorTerminalReason } from "./types.js";
+import type { OverlayHandle } from "@earendil-works/pi-tui";
+import type { HeadlessDispatchMonitor } from "./headless-monitor.ts";
+import type { MonitorConfig, MonitorEventPayload, MonitorSessionState, MonitorTerminalReason } from "./types.ts";
 
 const MONITOR_HISTORY_LIMIT = 200;
 

--- a/session-manager.ts
+++ b/session-manager.ts
@@ -1,4 +1,4 @@
-import { PtyTerminalSession } from "./pty-session.js";
+import { PtyTerminalSession } from "./pty-session.ts";
 
 export interface BackgroundSession {
 	id: string;

--- a/session-query.ts
+++ b/session-query.ts
@@ -1,7 +1,7 @@
-import type { InteractiveShellConfig } from "./config.js";
-import type { OutputOptions, OutputResult } from "./session-manager.js";
-import type { InteractiveShellResult } from "./types.js";
-import type { PtyTerminalSession } from "./pty-session.js";
+import type { InteractiveShellConfig } from "./config.ts";
+import type { OutputOptions, OutputResult } from "./session-manager.ts";
+import type { InteractiveShellResult } from "./types.ts";
+import type { PtyTerminalSession } from "./pty-session.ts";
 
 /** Mutable query bookkeeping kept per active session. */
 export interface SessionQueryState {

--- a/skills/pi-interactive-shell/SKILL.md
+++ b/skills/pi-interactive-shell/SKILL.md
@@ -493,7 +493,7 @@ The process is killed after timeout and captured output is returned in the hando
 - Capturing output from commands that don't exit cleanly
 - Any TUI command where you need quick output without user interaction
 
-For pi CLI documentation, you can also read directly: `/opt/homebrew/lib/node_modules/@mariozechner/pi-coding-agent/README.md`
+For pi CLI documentation, you can also read directly: `/opt/homebrew/lib/node_modules/@earendil-works/pi-coding-agent/README.md`
 
 ## Background Session Management
 

--- a/spawn.ts
+++ b/spawn.ts
@@ -1,7 +1,7 @@
 import { execFileSync } from "node:child_process";
 import { existsSync, mkdirSync } from "node:fs";
 import { basename, dirname, join, relative, resolve } from "node:path";
-import type { InteractiveShellConfig, SpawnAgent } from "./config.js";
+import type { InteractiveShellConfig, SpawnAgent } from "./config.ts";
 
 export type SpawnMode = "fresh" | "fork";
 export type SpawnMonitorMode = "hands-free" | "dispatch";

--- a/tests/command-session-selection.test.ts
+++ b/tests/command-session-selection.test.ts
@@ -70,7 +70,7 @@ async function setupHarness(initialSessions: MockBackgroundSession[]) {
 		ui: {
 			notify,
 			custom: vi.fn(),
-			select: vi.fn(async (_title: string, options: string[]) => options[0]),
+			select: vi.fn(async (_title: string, options: string[]): Promise<string | undefined> => options[0]),
 		},
 	};
 

--- a/tests/command-session-selection.test.ts
+++ b/tests/command-session-selection.test.ts
@@ -30,20 +30,20 @@ async function setupHarness(initialSessions: MockBackgroundSession[]) {
 	};
 
 	vi.resetModules();
-	vi.doMock("@mariozechner/pi-coding-agent", () => ({
+	vi.doMock("@earendil-works/pi-coding-agent", () => ({
 		getAgentDir: () => "/tmp/pi-agent",
 	}));
-	vi.doMock("@mariozechner/pi-tui", () => ({
+	vi.doMock("@earendil-works/pi-tui", () => ({
 		matchesKey: () => false,
 		truncateToWidth: (value: string) => value,
 		visibleWidth: (value: string) => value.length,
 	}));
-	vi.doMock("../session-manager.js", () => ({
+	vi.doMock("../session-manager.ts", () => ({
 		sessionManager,
 		generateSessionId: () => "mock-session-id",
 	}));
 
-	const extensionModule = await import("../index.js");
+	const extensionModule = await import("../index.ts");
 	const extension = extensionModule.default;
 
 	const commands = new Map<string, { handler: (args: string, ctx: any) => Promise<void> | void }>();
@@ -84,9 +84,9 @@ async function setupHarness(initialSessions: MockBackgroundSession[]) {
 
 describe("command session selection", () => {
 	afterEach(() => {
-		vi.doUnmock("@mariozechner/pi-coding-agent");
-		vi.doUnmock("@mariozechner/pi-tui");
-		vi.doUnmock("../session-manager.js");
+		vi.doUnmock("@earendil-works/pi-coding-agent");
+		vi.doUnmock("@earendil-works/pi-tui");
+		vi.doUnmock("../session-manager.ts");
 	});
 
 	it("/attach preserves full session id when id contains ' - '", async () => {

--- a/tests/config-and-docs.test.ts
+++ b/tests/config-and-docs.test.ts
@@ -5,15 +5,15 @@ import { join } from "node:path";
 
 async function loadConfigModule(agentDir: string) {
 	vi.resetModules();
-	vi.doMock("@mariozechner/pi-coding-agent", () => ({
+	vi.doMock("@earendil-works/pi-coding-agent", () => ({
 		getAgentDir: () => agentDir,
 	}));
-	return import("../config.js");
+	return import("../config.ts");
 }
 
 describe("config + docs parity", () => {
 	afterEach(() => {
-		vi.doUnmock("@mariozechner/pi-coding-agent");
+		vi.doUnmock("@earendil-works/pi-coding-agent");
 	});
 
 	it("merges global and project config with clamping", async () => {

--- a/tests/dispatch-background-recovery.test.ts
+++ b/tests/dispatch-background-recovery.test.ts
@@ -10,18 +10,18 @@ async function setupHarness() {
 	let toolDef: any;
 
 	vi.resetModules();
-	vi.doMock("@mariozechner/pi-coding-agent", () => ({
+	vi.doMock("@earendil-works/pi-coding-agent", () => ({
 		getAgentDir: () => "/tmp/pi-agent",
 	}));
-	vi.doMock("@mariozechner/pi-tui", () => ({
+	vi.doMock("@earendil-works/pi-tui", () => ({
 		isKeyRelease: () => false,
 		isKeyRepeat: () => false,
 		matchesKey: () => false,
 		truncateToWidth: (value: string) => value,
 		visibleWidth: (value: string) => value.length,
 	}));
-	vi.doMock("../config.js", async () => {
-		const actual = await vi.importActual<typeof import("../config.js")>("../config.js");
+	vi.doMock("../config.ts", async () => {
+		const actual = await vi.importActual<typeof import("../config.ts")>("../config.ts");
 		return {
 			...actual,
 			loadConfig: vi.fn(() => ({
@@ -59,13 +59,13 @@ async function setupHarness() {
 			})),
 		};
 	});
-	vi.doMock("../overlay-component.js", () => ({
+	vi.doMock("../overlay-component.ts", () => ({
 		InteractiveShellOverlay: class MockInteractiveShellOverlay {},
 	}));
-	vi.doMock("../reattach-overlay.js", () => ({
+	vi.doMock("../reattach-overlay.ts", () => ({
 		ReattachOverlay: class MockReattachOverlay {},
 	}));
-	vi.doMock("../session-manager.js", () => ({
+	vi.doMock("../session-manager.ts", () => ({
 		sessionManager: {
 			getActive: vi.fn(() => undefined),
 			unregisterActive,
@@ -86,7 +86,7 @@ async function setupHarness() {
 		},
 		generateSessionId: vi.fn(() => "start-session"),
 	}));
-	vi.doMock("../runtime-coordinator.js", () => ({
+	vi.doMock("../runtime-coordinator.ts", () => ({
 		InteractiveShellCoordinator: class MockCoordinator {
 			markAgentHandledCompletion = vi.fn();
 			consumeAgentHandledCompletion = vi.fn(() => false);
@@ -110,7 +110,7 @@ async function setupHarness() {
 		},
 	}));
 
-	const extensionModule = await import("../index.js");
+	const extensionModule = await import("../index.ts");
 	extensionModule.default({
 		registerShortcut: vi.fn(),
 		registerCommand: vi.fn(),
@@ -127,13 +127,13 @@ async function setupHarness() {
 
 describe("dispatch background recovery", () => {
 	afterEach(() => {
-		vi.doUnmock("@mariozechner/pi-coding-agent");
-		vi.doUnmock("@mariozechner/pi-tui");
-		vi.doUnmock("../config.js");
-		vi.doUnmock("../overlay-component.js");
-		vi.doUnmock("../reattach-overlay.js");
-		vi.doUnmock("../session-manager.js");
-		vi.doUnmock("../runtime-coordinator.js");
+		vi.doUnmock("@earendil-works/pi-coding-agent");
+		vi.doUnmock("@earendil-works/pi-tui");
+		vi.doUnmock("../config.ts");
+		vi.doUnmock("../overlay-component.ts");
+		vi.doUnmock("../reattach-overlay.ts");
+		vi.doUnmock("../session-manager.ts");
+		vi.doUnmock("../runtime-coordinator.ts");
 	});
 
 	it("releases the source session and disposes monitor when background session lookup fails", async () => {

--- a/tests/headless-monitor.test.ts
+++ b/tests/headless-monitor.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { HeadlessDispatchMonitor } from "../headless-monitor.js";
-import type { InteractiveShellConfig } from "../config.js";
+import { HeadlessDispatchMonitor } from "../headless-monitor.ts";
+import type { InteractiveShellConfig } from "../config.ts";
 
 const config: InteractiveShellConfig = {
 	exitAutoCloseDelay: 10,

--- a/tests/input-submit.test.ts
+++ b/tests/input-submit.test.ts
@@ -21,20 +21,20 @@ async function setupHarness() {
 	};
 
 	vi.resetModules();
-	vi.doMock("@mariozechner/pi-coding-agent", () => ({
+	vi.doMock("@earendil-works/pi-coding-agent", () => ({
 		getAgentDir: () => "/tmp/pi-agent",
 	}));
-	vi.doMock("@mariozechner/pi-tui", () => ({
+	vi.doMock("@earendil-works/pi-tui", () => ({
 		matchesKey: () => false,
 		truncateToWidth: (value: string) => value,
 		visibleWidth: (value: string) => value.length,
 	}));
-	vi.doMock("../session-manager.js", () => ({
+	vi.doMock("../session-manager.ts", () => ({
 		sessionManager,
 		generateSessionId: () => "mock-session-id",
 	}));
 
-	const extensionModule = await import("../index.js");
+	const extensionModule = await import("../index.ts");
 	const extension = extensionModule.default;
 
 	let registeredTool: { execute: (...args: any[]) => Promise<any> } | null = null;
@@ -71,9 +71,9 @@ async function setupHarness() {
 
 describe("interactive_shell submit input helper", () => {
 	afterEach(() => {
-		vi.doUnmock("@mariozechner/pi-coding-agent");
-		vi.doUnmock("@mariozechner/pi-tui");
-		vi.doUnmock("../session-manager.js");
+		vi.doUnmock("@earendil-works/pi-coding-agent");
+		vi.doUnmock("@earendil-works/pi-tui");
+		vi.doUnmock("../session-manager.ts");
 	});
 
 	it("mentions submit=true in the prompt snippet so agents are nudged toward real submission", async () => {

--- a/tests/input-submit.test.ts
+++ b/tests/input-submit.test.ts
@@ -52,7 +52,8 @@ async function setupHarness() {
 	extension(pi as any);
 
 	return {
-		tool: registeredTool,
+		// TS narrows the closure-assigned local to null here; the runtime value is set by registerTool.
+		tool: registeredTool as { execute: (...args: any[]) => Promise<any> } | null,
 		sessionManager,
 		ctx: {
 			cwd: "/tmp/project",

--- a/tests/key-encoding.test.ts
+++ b/tests/key-encoding.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { translateInput } from "../key-encoding.js";
+import { translateInput } from "../key-encoding.ts";
 
 describe("translateInput", () => {
 	it("encodes named keys and modifiers", () => {

--- a/tests/kill-session-suppression.test.ts
+++ b/tests/kill-session-suppression.test.ts
@@ -42,25 +42,25 @@ async function setupKillHarness(options: SetupOptions = {}) {
 
 	let coordinatorInstance: any;
 	vi.resetModules();
-	vi.doMock("@mariozechner/pi-coding-agent", () => ({
+	vi.doMock("@earendil-works/pi-coding-agent", () => ({
 		getAgentDir: () => "/tmp/pi-agent",
 	}));
-	vi.doMock("@mariozechner/pi-tui", () => ({
+	vi.doMock("@earendil-works/pi-tui", () => ({
 		matchesKey: () => false,
 		truncateToWidth: (value: string) => value,
 		visibleWidth: (value: string) => value.length,
 	}));
-	vi.doMock("../overlay-component.js", () => ({
+	vi.doMock("../overlay-component.ts", () => ({
 		InteractiveShellOverlay: class MockInteractiveShellOverlay {},
 	}));
-	vi.doMock("../reattach-overlay.js", () => ({
+	vi.doMock("../reattach-overlay.ts", () => ({
 		ReattachOverlay: class MockReattachOverlay {},
 	}));
-	vi.doMock("../session-manager.js", () => ({
+	vi.doMock("../session-manager.ts", () => ({
 		sessionManager,
 		generateSessionId: () => "mock-session-id",
 	}));
-	vi.doMock("../runtime-coordinator.js", () => ({
+	vi.doMock("../runtime-coordinator.ts", () => ({
 		InteractiveShellCoordinator: class MockCoordinator {
 			markAgentHandledCompletion = vi.fn();
 			consumeAgentHandledCompletion = vi.fn(() => false);
@@ -84,7 +84,7 @@ async function setupKillHarness(options: SetupOptions = {}) {
 		},
 	}));
 
-	const extensionModule = await import("../index.js");
+	const extensionModule = await import("../index.ts");
 	const extension = extensionModule.default;
 
 	let toolDef: any;
@@ -112,12 +112,12 @@ async function setupKillHarness(options: SetupOptions = {}) {
 
 describe("session kill completion suppression", () => {
 	afterEach(() => {
-		vi.doUnmock("@mariozechner/pi-coding-agent");
-		vi.doUnmock("@mariozechner/pi-tui");
-		vi.doUnmock("../overlay-component.js");
-		vi.doUnmock("../reattach-overlay.js");
-		vi.doUnmock("../runtime-coordinator.js");
-		vi.doUnmock("../session-manager.js");
+		vi.doUnmock("@earendil-works/pi-coding-agent");
+		vi.doUnmock("@earendil-works/pi-tui");
+		vi.doUnmock("../overlay-component.ts");
+		vi.doUnmock("../reattach-overlay.ts");
+		vi.doUnmock("../runtime-coordinator.ts");
+		vi.doUnmock("../session-manager.ts");
 	});
 
 	it("marks kill as agent-handled when the session has not completed yet", async () => {

--- a/tests/module-load.test.ts
+++ b/tests/module-load.test.ts
@@ -3,18 +3,18 @@ import { describe, expect, it, vi } from "vitest";
 describe("module smoke loads", () => {
 	it("loads the extension and overlay modules", async () => {
 		vi.resetModules();
-		vi.doMock("@mariozechner/pi-coding-agent", () => ({
+		vi.doMock("@earendil-works/pi-coding-agent", () => ({
 			getAgentDir: () => "/tmp/pi-agent",
 		}));
-		vi.doMock("@mariozechner/pi-tui", () => ({
+		vi.doMock("@earendil-works/pi-tui", () => ({
 			matchesKey: () => false,
 			truncateToWidth: (value: string) => value,
 			visibleWidth: (value: string) => value.length,
 		}));
 
-		const extension = await import("../index.js");
-		const overlay = await import("../overlay-component.js");
-		const reattach = await import("../reattach-overlay.js");
+		const extension = await import("../index.ts");
+		const overlay = await import("../overlay-component.ts");
+		const reattach = await import("../reattach-overlay.ts");
 		expect(typeof extension.default).toBe("function");
 		expect(typeof overlay.InteractiveShellOverlay).toBe("function");
 		expect(typeof reattach.ReattachOverlay).toBe("function");

--- a/tests/monitor-mode.test.ts
+++ b/tests/monitor-mode.test.ts
@@ -19,18 +19,18 @@ async function setupHarness() {
 	const sendMessage = vi.fn();
 
 	vi.resetModules();
-	vi.doMock("@mariozechner/pi-coding-agent", () => ({
+	vi.doMock("@earendil-works/pi-coding-agent", () => ({
 		getAgentDir: () => "/tmp/pi-agent",
 	}));
-	vi.doMock("@mariozechner/pi-tui", () => ({
+	vi.doMock("@earendil-works/pi-tui", () => ({
 		isKeyRelease: () => false,
 		isKeyRepeat: () => false,
 		matchesKey: () => false,
 		truncateToWidth: (value: string) => value,
 		visibleWidth: (value: string) => value.length,
 	}));
-	vi.doMock("../config.js", async () => {
-		const actual = await vi.importActual<typeof import("../config.js")>("../config.js");
+	vi.doMock("../config.ts", async () => {
+		const actual = await vi.importActual<typeof import("../config.ts")>("../config.ts");
 		return {
 			...actual,
 			loadConfig: vi.fn(() => ({
@@ -68,13 +68,13 @@ async function setupHarness() {
 			})),
 		};
 	});
-	vi.doMock("../overlay-component.js", () => ({
+	vi.doMock("../overlay-component.ts", () => ({
 		InteractiveShellOverlay: class MockInteractiveShellOverlay {},
 	}));
-	vi.doMock("../reattach-overlay.js", () => ({
+	vi.doMock("../reattach-overlay.ts", () => ({
 		ReattachOverlay: class MockReattachOverlay {},
 	}));
-	vi.doMock("../pty-session.js", () => ({
+	vi.doMock("../pty-session.ts", () => ({
 		PtyTerminalSession: class MockPtyTerminalSession {
 			exited = false;
 			exitCode: number | null = null;
@@ -92,7 +92,7 @@ async function setupHarness() {
 			getRawStream() { return ""; }
 		},
 	}));
-	vi.doMock("../headless-monitor.js", () => ({
+	vi.doMock("../headless-monitor.ts", () => ({
 		HeadlessDispatchMonitor: class MockHeadlessDispatchMonitor {
 			disposed = false;
 			constructor(
@@ -109,7 +109,7 @@ async function setupHarness() {
 			dispose() { this.disposed = true; }
 		},
 	}));
-	vi.doMock("../session-manager.js", () => ({
+	vi.doMock("../session-manager.ts", () => ({
 		sessionManager: {
 			getActive: vi.fn(() => undefined),
 			unregisterActive: vi.fn(),
@@ -131,7 +131,7 @@ async function setupHarness() {
 		generateSessionId: vi.fn(() => "monitor-1"),
 	}));
 
-	const extensionModule = await import("../index.js");
+	const extensionModule = await import("../index.ts");
 	extensionModule.default({
 		registerShortcut: vi.fn(),
 		registerCommand: vi.fn(),
@@ -154,14 +154,14 @@ async function setupHarness() {
 
 describe("monitor mode", () => {
 	afterEach(() => {
-		vi.doUnmock("@mariozechner/pi-coding-agent");
-		vi.doUnmock("@mariozechner/pi-tui");
-		vi.doUnmock("../config.js");
-		vi.doUnmock("../overlay-component.js");
-		vi.doUnmock("../reattach-overlay.js");
-		vi.doUnmock("../pty-session.js");
-		vi.doUnmock("../headless-monitor.js");
-		vi.doUnmock("../session-manager.js");
+		vi.doUnmock("@earendil-works/pi-coding-agent");
+		vi.doUnmock("@earendil-works/pi-tui");
+		vi.doUnmock("../config.ts");
+		vi.doUnmock("../overlay-component.ts");
+		vi.doUnmock("../reattach-overlay.ts");
+		vi.doUnmock("../pty-session.ts");
+		vi.doUnmock("../headless-monitor.ts");
+		vi.doUnmock("../session-manager.ts");
 	});
 
 	it("requires monitor object when mode is monitor", async () => {

--- a/tests/notification-utils.test.ts
+++ b/tests/notification-utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { buildDispatchNotification, buildHandsFreeUpdateMessage, buildIdlePromptWarning, buildMonitorEventNotification, buildMonitorLifecycleNotification, buildResultNotification } from "../notification-utils.js";
+import { buildDispatchNotification, buildHandsFreeUpdateMessage, buildIdlePromptWarning, buildMonitorEventNotification, buildMonitorLifecycleNotification, buildResultNotification } from "../notification-utils.ts";
 
 describe("notification utilities", () => {
 	it("formats compact dispatch notifications with a trimmed tail", () => {

--- a/tests/overlay-render.test.ts
+++ b/tests/overlay-render.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import type { InteractiveShellConfig } from "../config.js";
+import type { InteractiveShellConfig } from "../config.ts";
 
 const config: InteractiveShellConfig = {
 	exitAutoCloseDelay: 10,
@@ -66,15 +66,15 @@ function createExistingSession() {
 
 async function loadOverlay() {
 	vi.resetModules();
-	vi.doMock("@mariozechner/pi-tui", () => ({
+	vi.doMock("@earendil-works/pi-tui", () => ({
 		matchesKey: () => false,
 		truncateToWidth: (value: string, width: number) => value.length > width ? value.slice(0, width) : value,
 		visibleWidth: (value: string) => stripAnsi(value).length,
 	}));
-	vi.doMock("../pty-session.js", () => ({
+	vi.doMock("../pty-session.ts", () => ({
 		PtyTerminalSession: class MockPtyTerminalSession {},
 	}));
-	vi.doMock("../session-manager.js", () => ({
+	vi.doMock("../session-manager.ts", () => ({
 		sessionManager: {
 			registerActive: vi.fn(),
 			unregisterActive: vi.fn(),
@@ -82,26 +82,26 @@ async function loadOverlay() {
 		},
 		generateSessionId: vi.fn(() => "session-1"),
 	}));
-	vi.doMock("../handoff-utils.js", () => ({
+	vi.doMock("../handoff-utils.ts", () => ({
 		captureCompletionOutput: vi.fn(() => undefined),
 		captureTransferOutput: vi.fn(() => undefined),
 		maybeBuildHandoffPreview: vi.fn(() => undefined),
 		maybeWriteHandoffSnapshot: vi.fn(() => undefined),
 	}));
-	vi.doMock("../session-query.js", () => ({
+	vi.doMock("../session-query.ts", () => ({
 		createSessionQueryState: vi.fn(() => ({})),
 		getSessionOutput: vi.fn(() => ({ output: "", truncated: false, totalBytes: 0 })),
 	}));
-	return import("../overlay-component.js");
+	return import("../overlay-component.ts");
 }
 
 describe("InteractiveShellOverlay render focus cues", () => {
 	afterEach(() => {
-		vi.doUnmock("@mariozechner/pi-tui");
-		vi.doUnmock("../pty-session.js");
-		vi.doUnmock("../session-manager.js");
-		vi.doUnmock("../handoff-utils.js");
-		vi.doUnmock("../session-query.js");
+		vi.doUnmock("@earendil-works/pi-tui");
+		vi.doUnmock("../pty-session.ts");
+		vi.doUnmock("../session-manager.ts");
+		vi.doUnmock("../handoff-utils.ts");
+		vi.doUnmock("../session-query.ts");
 	});
 
 	it("shows distinct badges and border styles for focused and unfocused states", async () => {

--- a/tests/overlay-shortcuts.test.ts
+++ b/tests/overlay-shortcuts.test.ts
@@ -16,10 +16,10 @@ async function setupHarness(): Promise<Harness> {
 	const notify = vi.fn();
 
 	vi.resetModules();
-	vi.doMock("@mariozechner/pi-coding-agent", () => ({
+	vi.doMock("@earendil-works/pi-coding-agent", () => ({
 		getAgentDir: () => "/tmp/pi-agent",
 	}));
-	vi.doMock("@mariozechner/pi-tui", () => ({
+	vi.doMock("@earendil-works/pi-tui", () => ({
 		isKeyRelease: (data: string) => data === "RELEASE",
 		isKeyRepeat: (data: string) => data === "REPEAT",
 		matchesKey: (data: string, key: string) => {
@@ -30,22 +30,22 @@ async function setupHarness(): Promise<Harness> {
 		truncateToWidth: (value: string) => value,
 		visibleWidth: (value: string) => value.length,
 	}));
-	vi.doMock("../overlay-component.js", () => ({
+	vi.doMock("../overlay-component.ts", () => ({
 		InteractiveShellOverlay: class MockInteractiveShellOverlay {},
 	}));
-	vi.doMock("../reattach-overlay.js", () => ({
+	vi.doMock("../reattach-overlay.ts", () => ({
 		ReattachOverlay: class MockReattachOverlay {},
 	}));
-	vi.doMock("../pty-session.js", () => ({
+	vi.doMock("../pty-session.ts", () => ({
 		PtyTerminalSession: class MockPtyTerminalSession {},
 	}));
-	vi.doMock("../headless-monitor.js", () => ({
+	vi.doMock("../headless-monitor.ts", () => ({
 		HeadlessDispatchMonitor: class MockHeadlessDispatchMonitor {},
 	}));
-	vi.doMock("../background-widget.js", () => ({
+	vi.doMock("../background-widget.ts", () => ({
 		setupBackgroundWidget: vi.fn(() => vi.fn()),
 	}));
-	vi.doMock("../session-manager.js", () => ({
+	vi.doMock("../session-manager.ts", () => ({
 		sessionManager: {
 			killAll: vi.fn(),
 			onChange: vi.fn(() => () => {}),
@@ -66,7 +66,7 @@ async function setupHarness(): Promise<Harness> {
 		},
 		generateSessionId: vi.fn(() => "id"),
 	}));
-	vi.doMock("../runtime-coordinator.js", () => ({
+	vi.doMock("../runtime-coordinator.ts", () => ({
 		InteractiveShellCoordinator: class MockCoordinator {
 			overlayOpen = false;
 			overlayFocused = false;
@@ -97,7 +97,7 @@ async function setupHarness(): Promise<Harness> {
 		},
 	}));
 
-	const extensionModule = await import("../index.js");
+	const extensionModule = await import("../index.ts");
 	const extension = extensionModule.default;
 
 	const handlers = new Map<string, any>();
@@ -143,15 +143,15 @@ async function setupHarness(): Promise<Harness> {
 
 describe("overlay focus and side-chat guards", () => {
 	afterEach(() => {
-		vi.doUnmock("@mariozechner/pi-coding-agent");
-		vi.doUnmock("@mariozechner/pi-tui");
-		vi.doUnmock("../overlay-component.js");
-		vi.doUnmock("../reattach-overlay.js");
-		vi.doUnmock("../pty-session.js");
-		vi.doUnmock("../headless-monitor.js");
-		vi.doUnmock("../background-widget.js");
-		vi.doUnmock("../session-manager.js");
-		vi.doUnmock("../runtime-coordinator.js");
+		vi.doUnmock("@earendil-works/pi-coding-agent");
+		vi.doUnmock("@earendil-works/pi-tui");
+		vi.doUnmock("../overlay-component.ts");
+		vi.doUnmock("../reattach-overlay.ts");
+		vi.doUnmock("../pty-session.ts");
+		vi.doUnmock("../headless-monitor.ts");
+		vi.doUnmock("../background-widget.ts");
+		vi.doUnmock("../session-manager.ts");
+		vi.doUnmock("../runtime-coordinator.ts");
 	});
 
 	it("toggles overlay focus globally while the overlay is open", async () => {

--- a/tests/runtime-coordinator.test.ts
+++ b/tests/runtime-coordinator.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { InteractiveShellCoordinator } from "../runtime-coordinator.js";
+import { InteractiveShellCoordinator } from "../runtime-coordinator.ts";
 
 describe("InteractiveShellCoordinator monitor state", () => {
 	it("tracks monitor session lifecycle and filtered event queries", () => {

--- a/tests/session-manager.test.ts
+++ b/tests/session-manager.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { ShellSessionManager } from "../session-manager.js";
+import { ShellSessionManager } from "../session-manager.ts";
 
 function createSession() {
 	return {

--- a/tests/session-query.test.ts
+++ b/tests/session-query.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
-import { createSessionQueryState, getSessionOutput } from "../session-query.js";
-import type { InteractiveShellConfig } from "../config.js";
+import { createSessionQueryState, getSessionOutput } from "../session-query.ts";
+import type { InteractiveShellConfig } from "../config.ts";
 
 const config: InteractiveShellConfig = {
 	exitAutoCloseDelay: 10,

--- a/tests/spawn-command.test.ts
+++ b/tests/spawn-command.test.ts
@@ -19,16 +19,16 @@ async function setupExtensionHarness(configOverrides: SpawnConfigOverrides = {})
 	let registeredTool: { execute: (...args: any[]) => Promise<any> } | null = null;
 
 	vi.resetModules();
-	vi.doMock("@mariozechner/pi-coding-agent", () => ({
+	vi.doMock("@earendil-works/pi-coding-agent", () => ({
 		getAgentDir: () => "/tmp/pi-agent",
 	}));
-	vi.doMock("@mariozechner/pi-tui", () => ({
+	vi.doMock("@earendil-works/pi-tui", () => ({
 		matchesKey: () => false,
 		truncateToWidth: (value: string) => value,
 		visibleWidth: (value: string) => value.length,
 	}));
-	vi.doMock("../config.js", async () => {
-		const actual = await vi.importActual<typeof import("../config.js")>("../config.js");
+	vi.doMock("../config.ts", async () => {
+		const actual = await vi.importActual<typeof import("../config.ts")>("../config.ts");
 		return {
 			...actual,
 			loadConfig: vi.fn(() => ({
@@ -76,22 +76,22 @@ async function setupExtensionHarness(configOverrides: SpawnConfigOverrides = {})
 			})),
 		};
 	});
-	vi.doMock("../overlay-component.js", () => ({
+	vi.doMock("../overlay-component.ts", () => ({
 		InteractiveShellOverlay: class MockInteractiveShellOverlay {
 			constructor(_tui: unknown, _theme: unknown, options: { command: string; reason?: string; cwd?: string }) {
 				lastOverlayOptions = { command: options.command, reason: options.reason, cwd: options.cwd };
 			}
 		},
 	}));
-	vi.doMock("../spawn.js", async () => {
-		const actual = await vi.importActual<typeof import("../spawn.js")>("../spawn.js");
+	vi.doMock("../spawn.ts", async () => {
+		const actual = await vi.importActual<typeof import("../spawn.ts")>("../spawn.ts");
 		return {
 			...actual,
 			resolveSpawn: vi.fn((config, cwd, request, getSessionFile) => actual.resolveSpawn(config, cwd, request, getSessionFile)),
 		};
 	});
 
-	const extensionModule = await import("../index.js");
+	const extensionModule = await import("../index.ts");
 	const extension = extensionModule.default;
 
 	const commands = new Map<string, { handler: (args: string, ctx: any) => Promise<void> | void }>();
@@ -153,11 +153,11 @@ async function setupExtensionHarness(configOverrides: SpawnConfigOverrides = {})
 
 describe("/spawn command, shortcut, and tool spawn", () => {
 	afterEach(() => {
-		vi.doUnmock("@mariozechner/pi-coding-agent");
-		vi.doUnmock("@mariozechner/pi-tui");
-		vi.doUnmock("../config.js");
-		vi.doUnmock("../overlay-component.js");
-		vi.doUnmock("../spawn.js");
+		vi.doUnmock("@earendil-works/pi-coding-agent");
+		vi.doUnmock("@earendil-works/pi-tui");
+		vi.doUnmock("../config.ts");
+		vi.doUnmock("../overlay-component.ts");
+		vi.doUnmock("../spawn.ts");
 	});
 
 	it("/spawn defaults to the configured default agent", async () => {

--- a/tests/spawn.test.ts
+++ b/tests/spawn.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import type { InteractiveShellConfig } from "../config.js";
+import type { InteractiveShellConfig } from "../config.ts";
 
 const config: InteractiveShellConfig = {
 	exitAutoCloseDelay: 10,
@@ -41,7 +41,7 @@ describe("spawn helpers", () => {
 	});
 
 	it("parses canonical agent tokens, mode, worktree flag, prompt, and monitor mode", async () => {
-		const { parseSpawnArgs } = await import("../spawn.js");
+		const { parseSpawnArgs } = await import("../spawn.ts");
 		expect(parseSpawnArgs('claude "review the diffs" --dispatch')).toEqual({
 			ok: true,
 			parsed: {
@@ -73,7 +73,7 @@ describe("spawn helpers", () => {
 	});
 
 	it("rejects invalid prompt-bearing combinations and unknown tokens", async () => {
-		const { parseSpawnArgs } = await import("../spawn.js");
+		const { parseSpawnArgs } = await import("../spawn.ts");
 		expect(parseSpawnArgs("claude-code")).toEqual({
 			ok: false,
 			error: "Unknown /spawn argument: claude-code",
@@ -97,7 +97,7 @@ describe("spawn helpers", () => {
 	});
 
 	it("resolves the configured default agent and default args", async () => {
-		const { resolveSpawn } = await import("../spawn.js");
+		const { resolveSpawn } = await import("../spawn.ts");
 		const result = resolveSpawn({
 			...config,
 			spawn: { ...config.spawn, defaultAgent: "codex" },
@@ -116,7 +116,7 @@ describe("spawn helpers", () => {
 	});
 
 	it("appends prompt text using each CLI's native startup form", async () => {
-		const { resolveSpawn } = await import("../spawn.js");
+		const { resolveSpawn } = await import("../spawn.ts");
 		expect(resolveSpawn(config, "/tmp/project", { agent: "claude", prompt: "review the diffs" }, () => "/tmp/project/session.jsonl")).toEqual({
 			ok: true,
 			spawn: {
@@ -153,7 +153,7 @@ describe("spawn helpers", () => {
 	});
 
 	it("rejects empty structured spawn prompts", async () => {
-		const { resolveSpawn } = await import("../spawn.js");
+		const { resolveSpawn } = await import("../spawn.ts");
 		expect(resolveSpawn(config, "/tmp/project", { agent: "codex", prompt: "   " }, () => "/tmp/project/session.jsonl")).toEqual({
 			ok: false,
 			error: "Spawn prompt cannot be empty.",
@@ -161,7 +161,7 @@ describe("spawn helpers", () => {
 	});
 
 	it("keeps fork pi-only", async () => {
-		const { resolveSpawn } = await import("../spawn.js");
+		const { resolveSpawn } = await import("../spawn.ts");
 		expect(resolveSpawn(config, "/tmp/project", { agent: "claude", mode: "fork" }, () => "/tmp/project/session.jsonl")).toEqual({
 			ok: false,
 			error: "Cannot fork claude. Fork is only supported for pi sessions.",
@@ -171,7 +171,7 @@ describe("spawn helpers", () => {
 	it("fails fork before creating a worktree when no session file is available", async () => {
 		const execFileSync = vi.fn();
 		vi.doMock("node:child_process", () => ({ execFileSync }));
-		const { resolveSpawn } = await import("../spawn.js");
+		const { resolveSpawn } = await import("../spawn.ts");
 		expect(resolveSpawn({
 			...config,
 			spawn: { ...config.spawn, worktree: true },
@@ -198,7 +198,7 @@ describe("spawn helpers", () => {
 			const actual = await vi.importActual<typeof import("node:fs")>("node:fs");
 			return { ...actual, existsSync: vi.fn(() => true), mkdirSync: vi.fn() };
 		});
-		const { resolveSpawn } = await import("../spawn.js");
+		const { resolveSpawn } = await import("../spawn.ts");
 		const result = resolveSpawn(config, "/tmp/repo/packages/app", { agent: "codex", worktree: true }, () => "/tmp/repo/session.jsonl");
 		expect(result.ok).toBe(true);
 		if (!result.ok) return;

--- a/tool-schema.ts
+++ b/tool-schema.ts
@@ -1,4 +1,4 @@
-import { Type } from "typebox";
+import { Type, type Static } from "typebox";
 
 export const TOOL_NAME = "interactive_shell";
 export const TOOL_LABEL = "Interactive Shell";
@@ -373,7 +373,10 @@ export const toolParameters = Type.Object({
 	handsFree: Type.Optional(
 		Type.Object({
 			updateMode: Type.Optional(
-				Type.String({
+				Type.Union([
+					Type.Literal("on-quiet"),
+					Type.Literal("interval"),
+				], {
 					description: "Update mode: 'on-quiet' (default, emit when output stops) or 'interval' (emit on fixed schedule)",
 				}),
 			),
@@ -422,63 +425,5 @@ export const toolParameters = Type.Object({
 	),
 });
 
-/** Parsed tool parameters type */
-export interface ToolParams {
-	command?: string;
-	spawn?: { agent?: "pi" | "codex" | "claude" | "cursor"; mode?: "fresh" | "fork"; worktree?: boolean; prompt?: string };
-	sessionId?: string;
-	kill?: boolean;
-	outputLines?: number;
-	outputMaxChars?: number;
-	outputOffset?: number;
-	drain?: boolean;
-	incremental?: boolean;
-	settings?: { updateInterval?: number; quietThreshold?: number };
-	input?: string;
-	submit?: boolean;
-	inputKeys?: string[];
-	inputHex?: string[];
-	inputPaste?: string;
-	cwd?: string;
-	name?: string;
-	reason?: string;
-	mode?: "interactive" | "hands-free" | "dispatch" | "monitor";
-	background?: boolean;
-	monitor?: {
-		strategy?: "stream" | "poll-diff" | "file-watch";
-		triggers: Array<{
-			id: string;
-			literal?: string;
-			regex?: string;
-			cooldownMs?: number;
-			threshold?: { captureGroup: number; op: "lt" | "lte" | "gt" | "gte"; value: number };
-		}>;
-		fileWatch?: { path: string; recursive?: boolean; events?: Array<"rename" | "change"> };
-		poll?: { intervalMs?: number };
-		persistence?: { stopAfterFirstEvent?: boolean; maxEvents?: number };
-		throttle?: { dedupeExactLine?: boolean; cooldownMs?: number };
-		detector?: { detectorCommand: string; timeoutMs?: number };
-	};
-	attach?: string;
-	listBackground?: boolean;
-	dismissBackground?: boolean | string;
-	monitorStatus?: boolean;
-	monitorEvents?: boolean;
-	monitorSessionId?: string;
-	monitorEventLimit?: number;
-	monitorEventOffset?: number;
-	monitorSinceEventId?: number;
-	monitorTriggerId?: string;
-	handsFree?: {
-		updateMode?: "on-quiet" | "interval";
-		updateInterval?: number;
-		quietThreshold?: number;
-		gracePeriod?: number;
-		updateMaxChars?: number;
-		maxTotalChars?: number;
-		autoExitOnQuiet?: boolean;
-	};
-	handoffPreview?: { enabled?: boolean; lines?: number; maxChars?: number };
-	handoffSnapshot?: { enabled?: boolean; lines?: number; maxChars?: number };
-	timeout?: number;
-}
+/** Parsed tool parameters type, derived from the schema so the two cannot drift. */
+export type ToolParams = Static<typeof toolParameters>;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,18 @@
+{
+	"compilerOptions": {
+		"target": "ES2023",
+		"lib": ["ES2023"],
+		"module": "esnext",
+		"moduleResolution": "bundler",
+		"allowImportingTsExtensions": true,
+		"noEmit": true,
+		"strict": true,
+		"noImplicitOverride": true,
+		"noFallthroughCasesInSwitch": true,
+		"skipLibCheck": true,
+		"esModuleInterop": true,
+		"forceConsistentCasingInFileNames": true,
+		"types": ["node"]
+	},
+	"include": ["*.ts", "tests/**/*.ts"]
+}

--- a/types.ts
+++ b/types.ts
@@ -156,7 +156,7 @@ export interface InteractiveShellOptions {
 	// When false/undefined, keep registered so agent can query result later.
 	streamingMode?: boolean;
 	// Existing PTY session (for attach flow -- skip creating a new PTY)
-	existingSession?: import("./pty-session.js").PtyTerminalSession;
+	existingSession?: import("./pty-session.ts").PtyTerminalSession;
 	onUnfocus?: () => void;
 }
 


### PR DESCRIPTION
Brings the extension up to date with pi 0.82.1 and adds enforced type safety, in three commits.

The first commit is the mechanical migration: all imports move from the @mariozechner scope to @earendil-works, and local relative imports use .ts specifiers. Pi 0.82.1 still aliases the old scope for compatibility, so this is forward-looking cleanup rather than a breakage fix. Verified by loading index.ts through pi's own jiti loader configuration.

The second commit follows pi's package contract: @earendil-works/pi-coding-agent, @earendil-works/pi-tui, and typebox become peer dependencies with a * range, and engines.node matches pi's >=22.19.0 minimum. Pi installs packages with peer resolution disabled and resolves these modules through loader aliases, so the direct typebox dependency was redundant.

The third commit adds a strict tsconfig with an `npm run typecheck` script and fixes all 25 resulting errors. Notable changes beyond annotations: ToolParams is now derived from the typebox schema instead of a hand-written duplicate, which exposed real drift — the schema accepted any string for handsFree.updateMode while the code assumed 'on-quiet' | 'interval', so a junk value silently disabled both update modes; the schema now rejects it. CompiledMonitorConfig is a discriminated union so fileWatch exists exactly when strategy is file-watch. Config shortcuts are validated as key ids at load and fall back loudly instead of silently never matching. /dismiss no longer treats an unmatched select label as dismiss-all.

Verification: `npm run typecheck` clean, 74/74 tests passing at each commit boundary that touches code, and the extension loads through pi's real loader.