### PR TITLE
Support custom spawn agents from config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to the `pi-interactive-shell` extension will be documented i
 
 ## [Unreleased]
 
+### Added
+- Custom spawn agents (#16, reported by @krikchaip). Any key under `spawn.commands` is now a real spawn agent, usable through `spawn: { agent: "..." }`, `/spawn <agent>`, `spawn.defaultAgent`, `spawn.defaultArgs`, worktrees, and prompt passthrough. Agent names are validated when config loads, `fresh`/`fork` stay reserved `/spawn` keywords, `fork` stays Pi-only, and an unconfigured agent now fails with the list of configured agents instead of building a broken command.
+
 ### Changed
 - Cut over to the current pi package scope: all imports now use `@earendil-works/pi-coding-agent` and `@earendil-works/pi-tui`, and local module specifiers use `.ts` extensions.
 - Declared `@earendil-works/pi-coding-agent`, `@earendil-works/pi-tui`, and `typebox` as peer dependencies with a `*` range, following pi's package contract. `typebox` is no longer a direct dependency because pi resolves all of these through its extension loader aliases.

--- a/README.md
+++ b/README.md
@@ -81,6 +81,8 @@ interactive_shell({ spawn: { mode: "fork" }, mode: "interactive" })
 
 Structured `spawn` uses the same resolver and config defaults as the user-facing `/spawn` command. Raw `command` is still supported for arbitrary CLIs and custom launch strings.
 
+Any extra key you add under `spawn.commands` becomes a first-class spawn agent, usable as `spawn: { agent: "aider" }` and `/spawn aider`, with its own `spawn.defaultArgs` entry, worktree support, and prompt passthrough. `fork` stays Pi-only. Agent names must start with a letter or digit, may contain letters, digits, `.`, `_`, and `-`, and cannot be `fresh` or `fork`, because those are `/spawn` keywords.
+
 For Codex image or design work, Codex can invoke `gpt-image-2` directly from the prompt. Natural language is usually enough, and `$imagegen` forces the image-generation tool when you need it. Attach references with `-i` for edits and iterations. See the bundled `codex-cli` skill for concrete examples. For Cursor CLI-specific command references, see the optional `examples/skills/cursor-cli` skill. Cursor structured spawn defaults to `--model composer-2-fast`, which explicitly selects Cursor's Composer 2 Fast model.
 
 ### Interactive
@@ -366,7 +368,7 @@ interactive_shell({ dismissBackground: "calm-reef" })        // specific session
 
 Monitor sessions work the same way — they're headless background sessions that wake you on monitor events instead of completion.
 
-User can also `/spawn` to launch the configured default spawn agent, `/spawn codex`, `/spawn cursor`, `/spawn claude`, `/spawn pi`, `/spawn fork`, or `/spawn pi fork`. Add `--worktree` to spawn in a separate git worktree, for example `/spawn cursor --worktree`, `/spawn codex --worktree`, or `/spawn pi fork --worktree`. Plain `/spawn cursor` stays a normal interactive overlay. `fork` is Pi-only. Worktrees are left in place and the overlay will tell you where they were created. `/attach` or `/attach <id>` reattaches, and `/dismiss` or `/dismiss <id>` cleans up from the chat. The keyboard spawn shortcut is separate from `/spawn` and uses `spawn.shortcut`.
+User can also `/spawn` to launch the configured default spawn agent, `/spawn codex`, `/spawn cursor`, `/spawn claude`, `/spawn pi`, `/spawn fork`, `/spawn pi fork`, or `/spawn <custom-agent>` for any agent added to `spawn.commands`. Add `--worktree` to spawn in a separate git worktree, for example `/spawn cursor --worktree`, `/spawn codex --worktree`, or `/spawn pi fork --worktree`. Plain `/spawn cursor` stays a normal interactive overlay. `fork` is Pi-only. Worktrees are left in place and the overlay will tell you where they were created. `/attach` or `/attach <id>` reattaches, and `/dismiss` or `/dismiss <id>` cleans up from the chat. The keyboard spawn shortcut is separate from `/spawn` and uses `spawn.shortcut`.
 
 ### Prompt-Bearing `/spawn`
 
@@ -412,13 +414,15 @@ Shortcut settings are pinned at startup. If you change `focusShortcut` or `spawn
       "pi": "pi",
       "codex": "codex",
       "claude": "claude",
-      "cursor": "agent"
+      "cursor": "agent",
+      "aider": "aider"
     },
     "defaultArgs": {
       "pi": [],
       "codex": [],
       "claude": [],
-      "cursor": ["--model", "composer-2-fast"]
+      "cursor": ["--model", "composer-2-fast"],
+      "aider": ["--yes-always"]
     },
     "worktree": false,
     "worktreeBaseDir": "../repo-worktrees"
@@ -451,7 +455,7 @@ Shortcut settings are pinned at startup. If you change `focusShortcut` or `spawn
 | `focusShortcut` | "alt+shift+f" | Toggle focus between overlay and main chat |
 | `spawn.defaultAgent` | "pi" | Configured default spawn agent for `/spawn`, the spawn shortcut, and agent-side structured spawn |
 | `spawn.shortcut` | "alt+shift+p" | Keyboard shortcut that launches the configured default spawn agent |
-| `spawn.commands.<agent>` | `pi` / `codex` / `claude` / `agent` (cursor) | Executable or path override per spawn agent |
+| `spawn.commands.<agent>` | `pi` / `codex` / `claude` / `agent` (cursor) | Executable or path per spawn agent. Extra keys define custom spawn agents |
 | `spawn.defaultArgs.<agent>` | `[]` (Cursor defaults to `--model composer-2-fast`) | Extra default CLI args per spawn agent |
 | `spawn.worktree` | `false` | Launch spawns in a separate git worktree by default |
 | `spawn.worktreeBaseDir` | unset | Optional base directory for generated worktrees |

--- a/config.ts
+++ b/config.ts
@@ -3,7 +3,8 @@ import { join } from "node:path";
 import { getAgentDir } from "@earendil-works/pi-coding-agent";
 import type { KeyId } from "@earendil-works/pi-tui";
 
-export type SpawnAgent = "pi" | "codex" | "claude" | "cursor";
+/** A spawn agent is any key configured in `spawn.commands`, including the built-in defaults. */
+export type SpawnAgent = string;
 
 export interface SpawnConfig {
 	defaultAgent: SpawnAgent;
@@ -190,22 +191,11 @@ function mergeSpawnConfig(globalValue: unknown, projectValue: unknown): SpawnCon
 	const globalArgs = isPlainObject(globalSpawn?.defaultArgs) ? globalSpawn.defaultArgs : undefined;
 	const projectArgs = isPlainObject(projectSpawn?.defaultArgs) ? projectSpawn.defaultArgs : undefined;
 
-	const mergedCommands = {
-		pi: resolveNonEmptyString(projectCommands?.pi ?? globalCommands?.pi, DEFAULT_SPAWN_CONFIG.commands.pi),
-		codex: resolveNonEmptyString(projectCommands?.codex ?? globalCommands?.codex, DEFAULT_SPAWN_CONFIG.commands.codex),
-		claude: resolveNonEmptyString(projectCommands?.claude ?? globalCommands?.claude, DEFAULT_SPAWN_CONFIG.commands.claude),
-		cursor: resolveNonEmptyString(projectCommands?.cursor ?? globalCommands?.cursor, DEFAULT_SPAWN_CONFIG.commands.cursor),
-	};
-
-	const mergedDefaultArgs = {
-		pi: resolveStringArray(projectArgs?.pi ?? globalArgs?.pi, DEFAULT_SPAWN_CONFIG.defaultArgs.pi),
-		codex: resolveStringArray(projectArgs?.codex ?? globalArgs?.codex, DEFAULT_SPAWN_CONFIG.defaultArgs.codex),
-		claude: resolveStringArray(projectArgs?.claude ?? globalArgs?.claude, DEFAULT_SPAWN_CONFIG.defaultArgs.claude),
-		cursor: resolveStringArray(projectArgs?.cursor ?? globalArgs?.cursor, DEFAULT_SPAWN_CONFIG.defaultArgs.cursor),
-	};
+	const mergedCommands = mergeSpawnCommands(globalCommands, projectCommands);
+	const mergedDefaultArgs = mergeSpawnDefaultArgs(mergedCommands, globalArgs, projectArgs);
 
 	return {
-		defaultAgent: resolveSpawnAgent(projectSpawn?.defaultAgent ?? globalSpawn?.defaultAgent, DEFAULT_SPAWN_CONFIG.defaultAgent),
+		defaultAgent: resolveSpawnAgent(projectSpawn?.defaultAgent ?? globalSpawn?.defaultAgent, DEFAULT_SPAWN_CONFIG.defaultAgent, mergedCommands),
 		shortcut: resolveKeyId(projectSpawn?.shortcut ?? globalSpawn?.shortcut, DEFAULT_SPAWN_CONFIG.shortcut),
 		commands: mergedCommands,
 		defaultArgs: mergedDefaultArgs,
@@ -218,8 +208,57 @@ function isPlainObject(value: unknown): value is Record<string, unknown> {
 	return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
-function resolveSpawnAgent(value: unknown, fallback: SpawnAgent): SpawnAgent {
-	return value === "pi" || value === "codex" || value === "claude" || value === "cursor" ? value : fallback;
+/**
+ * Agent names double as `/spawn` tokens and as generated worktree directory segments, so they must
+ * not collide with `/spawn` mode keywords, start with a dash, or contain path/shell characters.
+ */
+const SPAWN_AGENT_NAME_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._-]*$/;
+const RESERVED_SPAWN_AGENT_NAMES = new Set(["fresh", "fork"]);
+
+function isSpawnAgentName(name: string): boolean {
+	return SPAWN_AGENT_NAME_PATTERN.test(name) && !RESERVED_SPAWN_AGENT_NAMES.has(name);
+}
+
+function mergeSpawnCommands(
+	globalCommands: Record<string, unknown> | undefined,
+	projectCommands: Record<string, unknown> | undefined,
+): Record<SpawnAgent, string> {
+	const commands: Record<SpawnAgent, string> = { ...DEFAULT_SPAWN_CONFIG.commands };
+	for (const source of [globalCommands, projectCommands]) {
+		for (const [name, value] of Object.entries(source ?? {})) {
+			if (!isSpawnAgentName(name)) {
+				console.error(`pi-interactive-shell: ignoring invalid spawn agent name "${name}" in config`);
+				continue;
+			}
+			const command = resolveOptionalString(value);
+			if (command) commands[name] = command;
+		}
+	}
+	return commands;
+}
+
+function mergeSpawnDefaultArgs(
+	commands: Record<SpawnAgent, string>,
+	globalArgs: Record<string, unknown> | undefined,
+	projectArgs: Record<string, unknown> | undefined,
+): Record<SpawnAgent, string[]> {
+	const defaultArgs: Record<SpawnAgent, string[]> = {};
+	for (const name of Object.keys(commands)) {
+		defaultArgs[name] = resolveStringArray(
+			projectArgs?.[name] ?? globalArgs?.[name],
+			DEFAULT_SPAWN_CONFIG.defaultArgs[name] ?? [],
+		);
+	}
+	return defaultArgs;
+}
+
+function resolveSpawnAgent(value: unknown, fallback: SpawnAgent, commands: Record<SpawnAgent, string>): SpawnAgent {
+	if (typeof value !== "string") return fallback;
+	const trimmed = value.trim();
+	if (trimmed.length === 0) return fallback;
+	if (commands[trimmed]) return trimmed;
+	console.error(`pi-interactive-shell: unknown spawn.defaultAgent "${trimmed}" in config, using "${fallback}"`);
+	return fallback;
 }
 
 function resolveStringArray(value: unknown, fallback: string[]): string[] {
@@ -246,12 +285,6 @@ function clampInt(value: number | undefined, fallback: number, min: number, max:
 	if (typeof value !== "number" || Number.isNaN(value)) return fallback;
 	const rounded = Math.trunc(value);
 	return Math.min(max, Math.max(min, rounded));
-}
-
-function resolveNonEmptyString(value: unknown, fallback: string): string {
-	if (typeof value !== "string") return fallback;
-	const trimmed = value.trim();
-	return trimmed.length > 0 ? trimmed : fallback;
 }
 
 const KEY_MODIFIERS = new Set(["ctrl", "shift", "alt", "super"]);

--- a/config.ts
+++ b/config.ts
@@ -211,12 +211,15 @@ function isPlainObject(value: unknown): value is Record<string, unknown> {
 /**
  * Agent names double as `/spawn` tokens and as generated worktree directory segments, so they must
  * not collide with `/spawn` mode keywords, start with a dash, or contain path/shell characters.
+ * Object.prototype member names are rejected too, so agent maps are never read through the prototype.
  */
 const SPAWN_AGENT_NAME_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._-]*$/;
 const RESERVED_SPAWN_AGENT_NAMES = new Set(["fresh", "fork"]);
 
 function isSpawnAgentName(name: string): boolean {
-	return SPAWN_AGENT_NAME_PATTERN.test(name) && !RESERVED_SPAWN_AGENT_NAMES.has(name);
+	return SPAWN_AGENT_NAME_PATTERN.test(name)
+		&& !RESERVED_SPAWN_AGENT_NAMES.has(name)
+		&& !(name in Object.prototype);
 }
 
 function mergeSpawnCommands(
@@ -256,7 +259,7 @@ function resolveSpawnAgent(value: unknown, fallback: SpawnAgent, commands: Recor
 	if (typeof value !== "string") return fallback;
 	const trimmed = value.trim();
 	if (trimmed.length === 0) return fallback;
-	if (commands[trimmed]) return trimmed;
+	if (Object.hasOwn(commands, trimmed)) return trimmed;
 	console.error(`pi-interactive-shell: unknown spawn.defaultAgent "${trimmed}" in config, using "${fallback}"`);
 	return fallback;
 }

--- a/index.ts
+++ b/index.ts
@@ -1649,11 +1649,12 @@ export default function interactiveShellExtension(pi: ExtensionAPI) {
 	}
 
 	pi.registerCommand("spawn", {
-		description: "Spawn the configured default agent, pi, codex, claude, or cursor in an interactive shell overlay",
+		description: "Spawn the configured default agent, a built-in agent, or a custom configured agent in an interactive shell overlay",
 		handler: async (args, ctx) => {
-			const parsed = parseSpawnArgs(args);
+			const agents = Object.keys(loadRuntimeConfig(ctx.cwd).spawn.commands).sort();
+			const parsed = parseSpawnArgs(args, agents);
 			if (!parsed.ok) {
-				ctx.ui.notify(`${parsed.error}\nUsage: /spawn [pi|codex|claude|cursor] [fresh|fork] [--worktree] [\"prompt\" --hands-free|--dispatch]`, "error");
+				ctx.ui.notify(`${parsed.error}\nUsage: /spawn [${agents.join("|")}] [fresh|fork] [--worktree] [\"prompt\" --hands-free|--dispatch]`, "error");
 				return;
 			}
 			if (parsed.parsed.monitorMode) {

--- a/skills/pi-interactive-shell/SKILL.md
+++ b/skills/pi-interactive-shell/SKILL.md
@@ -69,11 +69,11 @@ interactive_shell({ spawn: { agent: "claude", worktree: true }, mode: "hands-fre
 interactive_shell({ spawn: { mode: "fork" }, mode: "interactive" }) // Pi-only
 ```
 
-Structured `spawn` uses the same resolver and defaults as the user-facing `/spawn` command. Raw `command` is still the right choice for arbitrary CLIs and custom launch strings. Cursor structured spawn defaults to `--model composer-2-fast`, which explicitly selects Composer 2 Fast.
+Structured `spawn` uses the same resolver and defaults as the user-facing `/spawn` command. Raw `command` is still the right choice for arbitrary CLIs and custom launch strings. Users can add their own agents under `spawn.commands`; those keys work in `spawn: { agent: "..." }` just like the built-ins, and an unknown key returns the configured agent list as an error. Cursor structured spawn defaults to `--model composer-2-fast`, which explicitly selects Composer 2 Fast.
 
 For Codex image or design work, Codex can invoke `gpt-image-2` directly from the prompt. Natural language is usually enough, and `$imagegen` forces the image-generation tool when you need it. Attach references with `-i` for edits and iterations. See the bundled `codex-cli` skill for concrete examples.
 
-For users in chat, `/spawn` now supports the configured default agent plus explicit overrides like `/spawn codex`, `/spawn cursor`, `/spawn claude`, `/spawn pi`, `/spawn fork`, and `/spawn pi fork`. Add `--worktree` to run in a separate git worktree.
+For users in chat, `/spawn` now supports the configured default agent plus explicit overrides like `/spawn codex`, `/spawn cursor`, `/spawn claude`, `/spawn pi`, `/spawn fork`, `/spawn pi fork`, and any custom agent key from `spawn.commands`. Add `--worktree` to run in a separate git worktree.
 
 Quoted prompt text plus `--hands-free` or `--dispatch` turns `/spawn` into a monitored delegated run instead of a plain interactive overlay:
 

--- a/spawn.ts
+++ b/spawn.ts
@@ -130,7 +130,8 @@ export function resolveSpawn(
 		return { ok: false, error: "Spawn prompt cannot be empty." };
 	}
 
-	const executable = config.spawn.commands[agent];
+	// Own-property lookups only: an agent name like "constructor" must not resolve through Object.prototype.
+	const executable = Object.hasOwn(config.spawn.commands, agent) ? config.spawn.commands[agent] : undefined;
 	if (!executable) {
 		const configured = Object.keys(config.spawn.commands).sort().join(", ");
 		return { ok: false, error: `Unknown spawn agent: ${agent}. Configured agents: ${configured}.` };
@@ -159,7 +160,7 @@ export function resolveSpawn(
 		worktreePath = resolvedWorktree.path;
 	}
 
-	const args = [...(config.spawn.defaultArgs[agent] ?? [])];
+	const args = Object.hasOwn(config.spawn.defaultArgs, agent) ? [...config.spawn.defaultArgs[agent]] : [];
 	let reason = `spawn ${agent} (${mode === "fork" ? "fork current session" : "fresh session"})`;
 
 	if (sourceSessionFile) {

--- a/spawn.ts
+++ b/spawn.ts
@@ -27,7 +27,7 @@ export interface ResolvedSpawn {
 	worktreePath?: string;
 }
 
-export function parseSpawnArgs(args: string):
+export function parseSpawnArgs(args: string, agents: readonly SpawnAgent[]):
 	| { ok: true; parsed: ParsedSpawnArgs }
 	| { ok: false; error: string } {
 	const tokenized = tokenizeSpawnArgs(args);
@@ -59,18 +59,19 @@ export function parseSpawnArgs(args: string):
 			monitorMode = nextMonitorMode;
 			continue;
 		}
-		if (!token.quoted && (token.value === "pi" || token.value === "codex" || token.value === "claude" || token.value === "cursor")) {
-			if (agent) {
-				return { ok: false, error: `Duplicate spawn agent: ${token.value}` };
-			}
-			agent = token.value;
-			continue;
-		}
+		// Mode keywords are reserved, so they are matched before configured agent names.
 		if (!token.quoted && (token.value === "fresh" || token.value === "fork")) {
 			if (mode) {
 				return { ok: false, error: `Duplicate spawn mode: ${token.value}` };
 			}
 			mode = token.value;
+			continue;
+		}
+		if (!token.quoted && agents.includes(token.value)) {
+			if (agent) {
+				return { ok: false, error: `Duplicate spawn agent: ${token.value}` };
+			}
+			agent = token.value;
 			continue;
 		}
 		if (!token.quoted && token.value.startsWith("--")) {
@@ -129,6 +130,12 @@ export function resolveSpawn(
 		return { ok: false, error: "Spawn prompt cannot be empty." };
 	}
 
+	const executable = config.spawn.commands[agent];
+	if (!executable) {
+		const configured = Object.keys(config.spawn.commands).sort().join(", ");
+		return { ok: false, error: `Unknown spawn agent: ${agent}. Configured agents: ${configured}.` };
+	}
+
 	if (mode === "fork" && agent !== "pi") {
 		return { ok: false, error: `Cannot fork ${agent}. Fork is only supported for pi sessions.` };
 	}
@@ -152,8 +159,7 @@ export function resolveSpawn(
 		worktreePath = resolvedWorktree.path;
 	}
 
-	const executable = config.spawn.commands[agent];
-	const args = [...config.spawn.defaultArgs[agent]];
+	const args = [...(config.spawn.defaultArgs[agent] ?? [])];
 	let reason = `spawn ${agent} (${mode === "fork" ? "fork current session" : "fresh session"})`;
 
 	if (sourceSessionFile) {

--- a/tests/config-and-docs.test.ts
+++ b/tests/config-and-docs.test.ts
@@ -31,8 +31,8 @@ describe("config + docs parity", () => {
 			spawn: {
 				defaultAgent: "codex",
 				shortcut: "alt+s",
-				commands: { codex: "/opt/codex/bin/codex" },
-				defaultArgs: { codex: ["--no-alt-screen"] },
+				commands: { codex: "/opt/codex/bin/codex", aider: "aider", fork: "nope", "--bad": "nope" },
+				defaultArgs: { codex: ["--no-alt-screen"], aider: ["--yes-always"] },
 				worktree: true,
 				worktreeBaseDir: "../worktrees",
 			},
@@ -63,6 +63,10 @@ describe("config + docs parity", () => {
 		expect(config.spawn.defaultArgs.codex).toEqual(["--no-alt-screen"]);
 		expect(config.spawn.defaultArgs.claude).toEqual(["--allowedTools", "Bash"]);
 		expect(config.spawn.defaultArgs.cursor).toEqual(["--model", "composer-2-fast"]);
+		expect(config.spawn.commands.aider).toBe("aider");
+		expect(config.spawn.defaultArgs.aider).toEqual(["--yes-always"]);
+		expect(config.spawn.commands.fork).toBeUndefined();
+		expect(config.spawn.commands["--bad"]).toBeUndefined();
 		expect(config.spawn.worktree).toBe(false);
 		expect(config.spawn.worktreeBaseDir).toBe("../worktrees");
 
@@ -109,7 +113,7 @@ describe("config + docs parity", () => {
 		expect(skill).toContain('raw `input` only types text. It does not submit the prompt.');
 		expect(toolSchema).toContain(`default: ${defaults.handsFreeQuietThreshold}ms`);
 		expect(toolSchema).toContain('submit: true');
-		expect(toolSchema).toContain('Type.Literal("cursor")');
+		expect(toolSchema).toContain("or any custom key configured by the user");
 		expect(toolSchema).toContain('Structured \\`spawn\\` also supports a \\`prompt\\` field for Pi, Codex, Claude, and Cursor');
 		expect(toolSchema).toContain('This only types the text; it does not submit it.');
 		expect(toolSchema).toContain(`default: ${defaults.autoExitGracePeriod}ms`);

--- a/tests/spawn.test.ts
+++ b/tests/spawn.test.ts
@@ -133,6 +133,11 @@ describe("spawn helpers", () => {
 			ok: false,
 			error: "Unknown spawn agent: aider. Configured agents: claude, codex, cursor, pi.",
 		});
+		// Object.prototype member names must not resolve as configured agents.
+		expect(resolveSpawn(config, "/tmp/project", { agent: "constructor" }, () => undefined)).toEqual({
+			ok: false,
+			error: "Unknown spawn agent: constructor. Configured agents: claude, codex, cursor, pi.",
+		});
 	});
 
 	it("resolves the configured default agent and default args", async () => {

--- a/tests/spawn.test.ts
+++ b/tests/spawn.test.ts
@@ -35,6 +35,8 @@ const config: InteractiveShellConfig = {
 	minQueryIntervalSeconds: 60,
 };
 
+const AGENTS = ["pi", "codex", "claude", "cursor"];
+
 describe("spawn helpers", () => {
 	beforeEach(() => {
 		vi.resetModules();
@@ -42,28 +44,28 @@ describe("spawn helpers", () => {
 
 	it("parses canonical agent tokens, mode, worktree flag, prompt, and monitor mode", async () => {
 		const { parseSpawnArgs } = await import("../spawn.ts");
-		expect(parseSpawnArgs('claude "review the diffs" --dispatch')).toEqual({
+		expect(parseSpawnArgs('claude "review the diffs" --dispatch', AGENTS)).toEqual({
 			ok: true,
 			parsed: {
 				request: { agent: "claude", mode: undefined, worktree: undefined, prompt: "review the diffs" },
 				monitorMode: "dispatch",
 			},
 		});
-		expect(parseSpawnArgs("codex fork --worktree")).toEqual({
+		expect(parseSpawnArgs("codex fork --worktree", AGENTS)).toEqual({
 			ok: true,
 			parsed: {
 				request: { agent: "codex", mode: "fork", worktree: true, prompt: undefined },
 				monitorMode: undefined,
 			},
 		});
-		expect(parseSpawnArgs('cursor "review the diffs" --dispatch')).toEqual({
+		expect(parseSpawnArgs('cursor "review the diffs" --dispatch', AGENTS)).toEqual({
 			ok: true,
 			parsed: {
 				request: { agent: "cursor", mode: undefined, worktree: undefined, prompt: "review the diffs" },
 				monitorMode: "dispatch",
 			},
 		});
-		expect(parseSpawnArgs('"fix the failing tests" --hands-free')).toEqual({
+		expect(parseSpawnArgs('"fix the failing tests" --hands-free', AGENTS)).toEqual({
 			ok: true,
 			parsed: {
 				request: { agent: undefined, mode: undefined, worktree: undefined, prompt: "fix the failing tests" },
@@ -74,25 +76,62 @@ describe("spawn helpers", () => {
 
 	it("rejects invalid prompt-bearing combinations and unknown tokens", async () => {
 		const { parseSpawnArgs } = await import("../spawn.ts");
-		expect(parseSpawnArgs("claude-code")).toEqual({
+		expect(parseSpawnArgs("claude-code", AGENTS)).toEqual({
 			ok: false,
 			error: "Unknown /spawn argument: claude-code",
 		});
-		expect(parseSpawnArgs('claude "review the diffs"')).toEqual({
+		expect(parseSpawnArgs('claude "review the diffs"', AGENTS)).toEqual({
 			ok: false,
 			error: "Prompt-bearing /spawn requires --hands-free or --dispatch.",
 		});
-		expect(parseSpawnArgs("claude --dispatch")).toEqual({
+		expect(parseSpawnArgs("claude --dispatch", AGENTS)).toEqual({
 			ok: false,
 			error: "Monitored /spawn requires a quoted prompt, for example /spawn claude \"review the diffs\" --dispatch.",
 		});
-		expect(parseSpawnArgs("claude review the diffs --dispatch")).toEqual({
+		expect(parseSpawnArgs("claude review the diffs --dispatch", AGENTS)).toEqual({
 			ok: false,
 			error: "Unknown /spawn argument: review",
 		});
-		expect(parseSpawnArgs('claude "review" --dispatch --hands-free')).toEqual({
+		expect(parseSpawnArgs('claude "review" --dispatch --hands-free', AGENTS)).toEqual({
 			ok: false,
 			error: "Cannot combine --hands-free and --dispatch.",
+		});
+	});
+
+	it("accepts custom configured agents and resolves them through their command mapping", async () => {
+		const { parseSpawnArgs, resolveSpawn } = await import("../spawn.ts");
+		expect(parseSpawnArgs("aider --worktree", [...AGENTS, "aider"])).toEqual({
+			ok: true,
+			parsed: {
+				request: { agent: "aider", mode: undefined, worktree: true, prompt: undefined },
+				monitorMode: undefined,
+			},
+		});
+		expect(resolveSpawn({
+			...config,
+			spawn: {
+				...config.spawn,
+				commands: { ...config.spawn.commands, aider: "aider" },
+				defaultArgs: { ...config.spawn.defaultArgs, aider: ["--yes-always"] },
+			},
+		}, "/tmp/project", { agent: "aider", prompt: "fix the build" }, () => undefined)).toEqual({
+			ok: true,
+			spawn: {
+				agent: "aider",
+				mode: "fresh",
+				command: "aider --yes-always 'fix the build'",
+				cwd: "/tmp/project",
+				reason: "spawn aider (fresh session)",
+				worktreePath: undefined,
+			},
+		});
+	});
+
+	it("rejects agents that are not configured, listing the configured ones", async () => {
+		const { resolveSpawn } = await import("../spawn.ts");
+		expect(resolveSpawn(config, "/tmp/project", { agent: "aider" }, () => undefined)).toEqual({
+			ok: false,
+			error: "Unknown spawn agent: aider. Configured agents: claude, codex, cursor, pi.",
 		});
 	});
 

--- a/tool-schema.ts
+++ b/tool-schema.ts
@@ -125,6 +125,7 @@ DISMISS BACKGROUND SESSIONS:
 When using raw \`command\`, this tool does NOT inject prompts for you.
 If you want to start with a prompt, include it in the command using the CLI's own prompt form.
 Structured \`spawn\` also supports a \`prompt\` field for Pi, Codex, Claude, and Cursor using their native startup prompt forms.
+Users can configure extra spawn agents under \`spawn.commands\`; those custom keys work in \`spawn.agent\` exactly like the built-ins, and an unknown key returns the configured agent list as an error.
 
 Examples:
 - pi "Scan the current codebase"
@@ -145,13 +146,8 @@ export const toolParameters = Type.Object({
 	),
 	spawn: Type.Optional(
 		Type.Object({
-			agent: Type.Optional(Type.Union([
-				Type.Literal("pi"),
-				Type.Literal("codex"),
-				Type.Literal("claude"),
-				Type.Literal("cursor"),
-			], {
-				description: "Spawn agent to launch. Defaults to the configured spawn.defaultAgent.",
+			agent: Type.Optional(Type.String({
+				description: "Spawn agent key from spawn.commands: built-in 'pi', 'codex', 'claude', 'cursor', or any custom key configured by the user. Defaults to the configured spawn.defaultAgent.",
 			})),
 			mode: Type.Optional(Type.Union([
 				Type.Literal("fresh"),
@@ -163,10 +159,10 @@ export const toolParameters = Type.Object({
 				description: "Launch in a separate git worktree. Defaults to spawn.worktree from config.",
 			})),
 			prompt: Type.Optional(Type.String({
-				description: "Optional startup prompt for pi, codex, claude, or cursor. Uses each CLI's native prompt-bearing startup form.",
+				description: "Optional startup prompt, appended as the CLI's final argument. Uses each CLI's native prompt-bearing startup form.",
 			})),
 		}, {
-			description: "Structured spawn request for pi, codex, claude, or cursor. Use this instead of building the command string manually when you want the extension's spawn defaults, Pi-only fork behavior, worktree support, or native startup prompts.",
+			description: "Structured spawn request for any configured spawn agent. Use this instead of building the command string manually when you want the extension's spawn defaults, Pi-only fork behavior, worktree support, or native startup prompts.",
 		}),
 	),
 	sessionId: Type.Optional(


### PR DESCRIPTION
Closes #16, requested by @krikchaip.

Any key under `spawn.commands` is now a real spawn agent. It works in structured `interactive_shell({ spawn: { agent: "aider" } })`, in `/spawn aider`, as `spawn.defaultAgent`, and it picks up its own `spawn.defaultArgs`, worktree support, and prompt passthrough. The built-in pi/codex/claude/cursor defaults are unchanged.

A few decisions worth calling out:

Agent names are validated when config loads. They must start with a letter or digit and may contain letters, digits, `.`, `_`, `-`. `fresh` and `fork` are rejected because they are `/spawn` keywords. This keeps names unambiguous as `/spawn` tokens and safe as generated worktree directory segments. Invalid names are logged and skipped rather than silently accepted.

`/spawn` now matches mode keywords before agent names, and the parser takes the configured agent list so unknown tokens still produce a precise error and the usage line lists the agents you actually have.

`spawn.agent` in the tool schema is now a plain string. The runtime resolver is the validation boundary: an unconfigured agent fails with `Unknown spawn agent: X. Configured agents: ...` before any worktree is created, instead of building a command from an undefined executable.

`fork` stays Pi-only.

Verification: `npm run typecheck` clean, `npx vitest run` 17 files / 76 tests passing.
