### PR TITLE
Make overlay position configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to the `pi-interactive-shell` extension will be documented i
 ## [Unreleased]
 
 ### Added
+- `overlayAnchor` config (#3, reported by @ttttmr). The overlay was always centered; it can now be pinned to any of the nine host anchors, for example `"top-center"` to move it up. Invalid values warn and fall back to `center`.
 - Custom spawn agents (#16, reported by @krikchaip). Any key under `spawn.commands` is now a real spawn agent, usable through `spawn: { agent: "..." }`, `/spawn <agent>`, `spawn.defaultAgent`, `spawn.defaultArgs`, worktrees, and prompt passthrough. Agent names are validated when config loads, `fresh`/`fork` stay reserved `/spawn` keywords, `fork` stays Pi-only, and an unconfigured agent now fails with the list of configured agents instead of building a broken command.
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -406,6 +406,7 @@ Shortcut settings are pinned at startup. If you change `focusShortcut` or `spawn
 {
   "overlayWidthPercent": 95,
   "overlayHeightPercent": 60,
+  "overlayAnchor": "center",
   "focusShortcut": "alt+shift+f",
   "spawn": {
     "defaultAgent": "pi",
@@ -452,6 +453,7 @@ Shortcut settings are pinned at startup. If you change `focusShortcut` or `spawn
 |---------|---------|-------------|
 | `overlayWidthPercent` | 95 | Overlay width (10-100%) |
 | `overlayHeightPercent` | 60 | Overlay height (20-90%) |
+| `overlayAnchor` | "center" | Overlay position: `center`, `top-left`, `top-center`, `top-right`, `left-center`, `right-center`, `bottom-left`, `bottom-center`, `bottom-right` |
 | `focusShortcut` | "alt+shift+f" | Toggle focus between overlay and main chat |
 | `spawn.defaultAgent` | "pi" | Configured default spawn agent for `/spawn`, the spawn shortcut, and agent-side structured spawn |
 | `spawn.shortcut` | "alt+shift+p" | Keyboard shortcut that launches the configured default spawn agent |

--- a/config.ts
+++ b/config.ts
@@ -1,7 +1,7 @@
 import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import { getAgentDir } from "@earendil-works/pi-coding-agent";
-import type { KeyId } from "@earendil-works/pi-tui";
+import type { KeyId, OverlayAnchor } from "@earendil-works/pi-tui";
 
 /** A spawn agent is any key configured in `spawn.commands`, including the built-in defaults. */
 export type SpawnAgent = string;
@@ -19,6 +19,7 @@ export interface InteractiveShellConfig {
 	exitAutoCloseDelay: number;
 	overlayWidthPercent: number;
 	overlayHeightPercent: number;
+	overlayAnchor: OverlayAnchor;
 	focusShortcut: KeyId;
 	spawn: SpawnConfig;
 	scrollbackLines: number;
@@ -65,6 +66,7 @@ const DEFAULT_CONFIG: InteractiveShellConfig = {
 	exitAutoCloseDelay: 10,
 	overlayWidthPercent: 95,
 	overlayHeightPercent: 60,
+	overlayAnchor: "center",
 	focusShortcut: "alt+shift+f",
 	spawn: DEFAULT_SPAWN_CONFIG,
 	scrollbackLines: 5000,
@@ -119,6 +121,7 @@ export function loadConfig(cwd: string): InteractiveShellConfig {
 		exitAutoCloseDelay: clampInt(merged.exitAutoCloseDelay, DEFAULT_CONFIG.exitAutoCloseDelay, 0, 60),
 		overlayWidthPercent: clampPercent(merged.overlayWidthPercent, DEFAULT_CONFIG.overlayWidthPercent),
 		overlayHeightPercent: clampInt(merged.overlayHeightPercent, DEFAULT_CONFIG.overlayHeightPercent, 20, 90),
+		overlayAnchor: resolveOverlayAnchor(merged.overlayAnchor, DEFAULT_CONFIG.overlayAnchor),
 		focusShortcut: resolveKeyId(merged.focusShortcut, DEFAULT_CONFIG.focusShortcut),
 		spawn: mergedSpawn,
 		scrollbackLines: clampInt(merged.scrollbackLines, DEFAULT_CONFIG.scrollbackLines, 200, 50000),
@@ -277,6 +280,25 @@ function resolveOptionalString(value: unknown): string | undefined {
 	if (typeof value !== "string") return undefined;
 	const trimmed = value.trim();
 	return trimmed.length > 0 ? trimmed : undefined;
+}
+
+const OVERLAY_ANCHORS: readonly OverlayAnchor[] = [
+	"center", "top-left", "top-center", "top-right",
+	"left-center", "right-center",
+	"bottom-left", "bottom-center", "bottom-right",
+];
+
+function isOverlayAnchor(value: string): value is OverlayAnchor {
+	return (OVERLAY_ANCHORS as readonly string[]).includes(value);
+}
+
+function resolveOverlayAnchor(value: unknown, fallback: OverlayAnchor): OverlayAnchor {
+	if (typeof value !== "string") return fallback;
+	const trimmed = value.trim();
+	if (trimmed.length === 0) return fallback;
+	if (isOverlayAnchor(trimmed)) return trimmed;
+	console.error(`pi-interactive-shell: invalid overlayAnchor "${trimmed}" in config, using "${fallback}"`);
+	return fallback;
 }
 
 function clampPercent(value: number | undefined, fallback: number): number {

--- a/index.ts
+++ b/index.ts
@@ -669,7 +669,7 @@ export default function interactiveShellExtension(pi: ExtensionAPI) {
 		overlayOptions: {
 			width: `${config.overlayWidthPercent}%`,
 			maxHeight: `${config.overlayHeightPercent}%`,
-			anchor: "center",
+			anchor: config.overlayAnchor,
 			margin: 1,
 			nonCapturing: true,
 		},

--- a/tests/config-and-docs.test.ts
+++ b/tests/config-and-docs.test.ts
@@ -27,7 +27,6 @@ describe("config + docs parity", () => {
 		writeFileSync(globalPath, JSON.stringify({
 			handsFreeQuietThreshold: 999999,
 			overlayWidthPercent: 5,
-			overlayAnchor: "middle",
 			focusShortcut: "alt+f",
 			spawn: {
 				defaultAgent: "codex",

--- a/tests/config-and-docs.test.ts
+++ b/tests/config-and-docs.test.ts
@@ -27,6 +27,7 @@ describe("config + docs parity", () => {
 		writeFileSync(globalPath, JSON.stringify({
 			handsFreeQuietThreshold: 999999,
 			overlayWidthPercent: 5,
+			overlayAnchor: "middle",
 			focusShortcut: "alt+f",
 			spawn: {
 				defaultAgent: "codex",
@@ -40,6 +41,7 @@ describe("config + docs parity", () => {
 		writeFileSync(projectPath, JSON.stringify({
 			autoExitGracePeriod: 1,
 			overlayHeightPercent: 150,
+			overlayAnchor: "top-center",
 			focusShortcut: "   ",
 			spawn: {
 				shortcut: "   ",
@@ -55,6 +57,7 @@ describe("config + docs parity", () => {
 		expect(config.overlayWidthPercent).toBe(10);
 		expect(config.autoExitGracePeriod).toBe(5000);
 		expect(config.overlayHeightPercent).toBe(90);
+		expect(config.overlayAnchor).toBe("top-center");
 		expect(config.focusShortcut).toBe("alt+shift+f");
 		expect(config.spawn.defaultAgent).toBe("claude");
 		expect(config.spawn.shortcut).toBe("alt+shift+p");
@@ -83,6 +86,8 @@ describe("config + docs parity", () => {
 
 		expect(defaults.handsFreeQuietThreshold).toBe(8000);
 		expect(defaults.autoExitGracePeriod).toBe(15000);
+		expect(defaults.overlayAnchor).toBe("center");
+		expect(readme).toContain(`"overlayAnchor": "${defaults.overlayAnchor}"`);
 		expect(defaults.focusShortcut).toBe("alt+shift+f");
 		expect(defaults.spawn.defaultAgent).toBe("pi");
 		expect(defaults.spawn.shortcut).toBe("alt+shift+p");

--- a/tests/headless-monitor.test.ts
+++ b/tests/headless-monitor.test.ts
@@ -6,6 +6,7 @@ const config: InteractiveShellConfig = {
 	exitAutoCloseDelay: 10,
 	overlayWidthPercent: 95,
 	overlayHeightPercent: 60,
+	overlayAnchor: "center",
 	focusShortcut: "alt+shift+f",
 	spawn: {
 		defaultAgent: "pi",

--- a/tests/overlay-render.test.ts
+++ b/tests/overlay-render.test.ts
@@ -5,6 +5,7 @@ const config: InteractiveShellConfig = {
 	exitAutoCloseDelay: 10,
 	overlayWidthPercent: 95,
 	overlayHeightPercent: 60,
+	overlayAnchor: "center",
 	focusShortcut: "alt+shift+f",
 	spawn: {
 		defaultAgent: "pi",

--- a/tests/session-query.test.ts
+++ b/tests/session-query.test.ts
@@ -6,6 +6,7 @@ const config: InteractiveShellConfig = {
 	exitAutoCloseDelay: 10,
 	overlayWidthPercent: 95,
 	overlayHeightPercent: 60,
+	overlayAnchor: "center",
 	focusShortcut: "alt+shift+f",
 	spawn: {
 		defaultAgent: "pi",

--- a/tests/spawn.test.ts
+++ b/tests/spawn.test.ts
@@ -5,6 +5,7 @@ const config: InteractiveShellConfig = {
 	exitAutoCloseDelay: 10,
 	overlayWidthPercent: 95,
 	overlayHeightPercent: 60,
+	overlayAnchor: "center",
 	focusShortcut: "alt+shift+f",
 	spawn: {
 		defaultAgent: "pi",


### PR DESCRIPTION
Closes #3, reported by @ttttmr.

The size half of that issue was already addressed by `overlayWidthPercent` / `overlayHeightPercent` and the later default and footer changes. The position half was not: every overlay launch went through one helper that hard-coded `anchor: "center"`.

This adds `overlayAnchor`, accepting the nine anchors the host supports (`center`, `top-left`, `top-center`, `top-right`, `left-center`, `right-center`, `bottom-left`, `bottom-center`, `bottom-right`). Setting `"top-center"` is the direct answer to the request to move the window up. It is validated when config loads, in the same style as the shortcut validation: an unknown value warns and falls back to `center` instead of silently producing an invalid host option.

All five visible overlay launch paths share the same options helper, so spawn, tool, attach, and side-chat overlays pick this up together. Component PTY sizing is unchanged since it depends on the width/height percentages, not the anchor.

Verification: `npm run typecheck` clean, `npx vitest run` 17 files / 76 tests passing.
