### PR TITLE
Tighten TypeScript runtime boundaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to the `pi-interactive-shell` extension will be documented i
 - Custom spawn agents (#16, reported by @krikchaip). Any key under `spawn.commands` is now a real spawn agent, usable through `spawn: { agent: "..." }`, `/spawn <agent>`, `spawn.defaultAgent`, `spawn.defaultArgs`, worktrees, and prompt passthrough. Agent names are validated when config loads, `fresh`/`fork` stay reserved `/spawn` keywords, `fork` stays Pi-only, and an unconfigured agent now fails with the list of configured agents instead of building a broken command.
 
 ### Changed
+- Tightened TypeScript/runtime boundaries for config and output queries: config JSON roots are now validated before merging, non-finite numeric config/query values fall back to defaults, and monitor/PTY internals avoid unnecessary type assertions.
 - Cut over to the current pi package scope: all imports now use `@earendil-works/pi-coding-agent` and `@earendil-works/pi-tui`, and local module specifiers use `.ts` extensions.
 - Declared `@earendil-works/pi-coding-agent`, `@earendil-works/pi-tui`, and `typebox` as peer dependencies with a `*` range, following pi's package contract. `typebox` is no longer a direct dependency because pi resolves all of these through its extension loader aliases.
 - Added `engines.node: >=22.19.0` to match pi's minimum supported Node version.

--- a/config.ts
+++ b/config.ts
@@ -59,7 +59,6 @@ const DEFAULT_SPAWN_CONFIG: SpawnConfig = {
 		cursor: ["--model", "composer-2-fast"],
 	},
 	worktree: false,
-	worktreeBaseDir: undefined,
 };
 
 const DEFAULT_CONFIG: InteractiveShellConfig = {
@@ -94,24 +93,8 @@ export function loadConfig(cwd: string): InteractiveShellConfig {
 	const projectPath = join(cwd, ".pi", "interactive-shell.json");
 	const globalPath = join(getAgentDir(), "interactive-shell.json");
 
-	let globalConfig: Partial<InteractiveShellConfig> = {};
-	let projectConfig: Partial<InteractiveShellConfig> = {};
-
-	if (existsSync(globalPath)) {
-		try {
-			globalConfig = JSON.parse(readFileSync(globalPath, "utf-8"));
-		} catch (error) {
-			console.error(`Warning: Could not parse ${globalPath}:`, error);
-		}
-	}
-
-	if (existsSync(projectPath)) {
-		try {
-			projectConfig = JSON.parse(readFileSync(projectPath, "utf-8"));
-		} catch (error) {
-			console.error(`Warning: Could not parse ${projectPath}:`, error);
-		}
-	}
+	const globalConfig = loadConfigObject(globalPath);
+	const projectConfig = loadConfigObject(projectPath);
 
 	const mergedSpawn = mergeSpawnConfig(globalConfig.spawn, projectConfig.spawn);
 	const merged = { ...DEFAULT_CONFIG, ...globalConfig, ...projectConfig, spawn: mergedSpawn };
@@ -184,6 +167,18 @@ export function loadConfig(cwd: string): InteractiveShellConfig {
 			300,
 		),
 	};
+}
+
+function loadConfigObject(path: string): Record<string, unknown> {
+	if (!existsSync(path)) return {};
+	try {
+		const parsed: unknown = JSON.parse(readFileSync(path, "utf-8"));
+		if (isPlainObject(parsed)) return parsed;
+		console.error(`Warning: Ignoring ${path}: config root must be an object`);
+	} catch (error) {
+		console.error(`Warning: Could not parse ${path}:`, error);
+	}
+	return {};
 }
 
 function mergeSpawnConfig(globalValue: unknown, projectValue: unknown): SpawnConfig {
@@ -302,12 +297,12 @@ function resolveOverlayAnchor(value: unknown, fallback: OverlayAnchor): OverlayA
 }
 
 function clampPercent(value: number | undefined, fallback: number): number {
-	if (typeof value !== "number" || Number.isNaN(value)) return fallback;
+	if (typeof value !== "number" || !Number.isFinite(value)) return fallback;
 	return Math.min(100, Math.max(10, value));
 }
 
 function clampInt(value: number | undefined, fallback: number, min: number, max: number): number {
-	if (typeof value !== "number" || Number.isNaN(value)) return fallback;
+	if (typeof value !== "number" || !Number.isFinite(value)) return fallback;
 	const rounded = Math.trunc(value);
 	return Math.min(max, Math.max(min, rounded));
 }

--- a/headless-monitor.ts
+++ b/headless-monitor.ts
@@ -1,14 +1,15 @@
 import { stripVTControlCharacters } from "node:util";
 import type { PtyTerminalSession } from "./pty-session.ts";
 import type { InteractiveShellConfig } from "./config.ts";
+import type { MonitorEventPayload, MonitorStrategy } from "./types.ts";
 
 export interface MonitorMatchInfo {
-	strategy: "stream" | "poll-diff" | "file-watch";
+	strategy: MonitorStrategy;
 	triggerId: string;
 	eventType: string;
 	matchedText: string;
 	lineOrDiff: string;
-	stream: "pty";
+	stream: MonitorEventPayload["stream"];
 }
 
 export interface MonitorTriggerMatcher {
@@ -18,7 +19,7 @@ export interface MonitorTriggerMatcher {
 }
 
 export interface MonitorRuntimeConfig {
-	strategy: "stream" | "poll-diff" | "file-watch";
+	strategy: MonitorStrategy;
 	triggers: MonitorTriggerMatcher[];
 	pollIntervalMs: number;
 	dedupeExactLine: boolean;
@@ -244,8 +245,8 @@ export class HeadlessDispatchMonitor {
 	private emitMonitorEvent(event: MonitorMatchInfo): void {
 		try {
 			const maybePromise = this.options.onMonitorEvent?.(event);
-			if (maybePromise && typeof (maybePromise as Promise<unknown>).then === "function") {
-				void (maybePromise as Promise<unknown>).catch((error) => {
+			if (isPromiseLike(maybePromise)) {
+				void Promise.resolve(maybePromise).catch((error) => {
 					console.error("interactive-shell: monitor event callback error:", error);
 				});
 			}
@@ -366,6 +367,10 @@ export class HeadlessDispatchMonitor {
 		if (this.timeoutTimer) { clearTimeout(this.timeoutTimer); this.timeoutTimer = null; }
 		this.unsubscribe();
 	}
+}
+
+function isPromiseLike(value: unknown): value is PromiseLike<unknown> {
+	return typeof value === "object" && value !== null && "then" in value && typeof value.then === "function";
 }
 
 function normalizeMonitorSnapshot(raw: string): string {

--- a/pty-session.ts
+++ b/pty-session.ts
@@ -478,9 +478,9 @@ export class PtyTerminalSession {
 		let remainingChars = maxChars;
 		let truncatedByChars = false;
 
-		const useAnsi = options.ansi && this.serializer;
-		if (useAnsi) {
-			const serialized = this.serializer!.serialize();
+		const serializer = options.ansi ? this.serializer : undefined;
+		if (serializer) {
+			const serialized = serializer.serialize();
 			const serializedLines = serialized.split(/\r?\n/);
 			if (serializedLines.length >= totalLinesInBuffer) {
 				for (let i = start; i < totalLinesInBuffer; i++) {

--- a/runtime-coordinator.ts
+++ b/runtime-coordinator.ts
@@ -4,6 +4,15 @@ import type { MonitorConfig, MonitorEventPayload, MonitorSessionState, MonitorTe
 
 const MONITOR_HISTORY_LIMIT = 200;
 
+export interface MonitorEventsQueryResult {
+	events: MonitorEventPayload[];
+	total: number;
+	limit: number;
+	offset: number;
+	sinceEventId?: number;
+	triggerId?: string;
+}
+
 /** Centralizes overlay, monitor, widget, and completion-suppression state for the extension runtime. */
 export class InteractiveShellCoordinator {
 	private overlayOpen = false;
@@ -151,14 +160,7 @@ export class InteractiveShellCoordinator {
 		return recorded;
 	}
 
-	getMonitorEvents(sessionId: string, options?: { limit?: number; offset?: number; sinceEventId?: number; triggerId?: string }): {
-		events: MonitorEventPayload[];
-		total: number;
-		limit: number;
-		offset: number;
-		sinceEventId?: number;
-		triggerId?: string;
-	} {
+	getMonitorEvents(sessionId: string, options?: { limit?: number; offset?: number; sinceEventId?: number; triggerId?: string }): MonitorEventsQueryResult {
 		let events = this.monitorEventHistory.get(sessionId) ?? [];
 		const sinceEventId = options?.sinceEventId !== undefined ? Math.max(0, Math.trunc(options.sinceEventId)) : undefined;
 		if (sinceEventId !== undefined) {

--- a/session-query.ts
+++ b/session-query.ts
@@ -33,8 +33,8 @@ export function getSessionOutput(
 	}
 
 	const opts = typeof options === "boolean" ? { skipRateLimit: options } : options;
-	const requestedLines = clampPositive(opts.lines ?? DEFAULT_STATUS_LINES, MAX_STATUS_LINES);
-	const requestedMaxChars = clampPositive(opts.maxChars ?? DEFAULT_STATUS_OUTPUT, MAX_STATUS_OUTPUT);
+	const requestedLines = clampPositive(opts.lines, DEFAULT_STATUS_LINES, MAX_STATUS_LINES);
+	const requestedMaxChars = clampPositive(opts.maxChars, DEFAULT_STATUS_OUTPUT, MAX_STATUS_OUTPUT);
 	const rateLimited = maybeRateLimitQuery(config, state, opts.skipRateLimit ?? false);
 	if (rateLimited) return rateLimited;
 
@@ -165,6 +165,7 @@ function truncateForMaxChars(output: string, requestedMaxChars: number): { value
 	};
 }
 
-function clampPositive(value: number, max: number): number {
-	return Math.max(1, Math.min(max, value));
+function clampPositive(value: number | undefined, fallback: number, max: number): number {
+	if (typeof value !== "number" || !Number.isFinite(value)) return fallback;
+	return Math.max(1, Math.min(max, Math.trunc(value)));
 }

--- a/tests/config-and-docs.test.ts
+++ b/tests/config-and-docs.test.ts
@@ -75,6 +75,30 @@ describe("config + docs parity", () => {
 		rmSync(root, { recursive: true, force: true });
 	});
 
+	it("ignores invalid config roots and non-finite numeric config", async () => {
+		const root = mkdtempSync(join(tmpdir(), "interactive-shell-invalid-config-"));
+		const project = join(root, "project");
+		const agentDir = join(root, "agent");
+		const globalPath = join(agentDir, "interactive-shell.json");
+		const projectPath = join(project, ".pi", "interactive-shell.json");
+		mkdirSync(agentDir, { recursive: true });
+		mkdirSync(join(project, ".pi"), { recursive: true });
+		writeFileSync(globalPath, "[]", { encoding: "utf-8" });
+		writeFileSync(projectPath, '{ "overlayWidthPercent": 1e999, "scrollbackLines": -1e999 }', { encoding: "utf-8" });
+		const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+		try {
+			const { loadConfig } = await loadConfigModule(agentDir);
+			const config = loadConfig(project);
+
+			expect(config.overlayWidthPercent).toBe(95);
+			expect(config.scrollbackLines).toBe(5000);
+			expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining(`Ignoring ${globalPath}: config root must be an object`));
+		} finally {
+			errorSpy.mockRestore();
+			rmSync(root, { recursive: true, force: true });
+		}
+	});
+
 	it("keeps README, SKILL, and tool help defaults aligned with config defaults", async () => {
 		const root = mkdtempSync(join(tmpdir(), "interactive-shell-defaults-"));
 		const { loadConfig } = await loadConfigModule(root);

--- a/tests/session-query.test.ts
+++ b/tests/session-query.test.ts
@@ -100,6 +100,26 @@ describe("getSessionOutput", () => {
 		});
 	});
 
+	it("falls back for non-finite output query limits", () => {
+		const state = createSessionQueryState();
+		let captured: { lines: number; maxChars?: number } | undefined;
+		const session = {
+			getTailLines: (options: { lines: number; maxChars?: number }) => {
+				captured = options;
+				return { lines: ["alpha"], totalLinesInBuffer: 1, truncatedByChars: false };
+			},
+			getRawStream: () => "",
+			getLogSlice: () => ({ slice: "", totalLines: 0, totalChars: 0, sliceLineCount: 0 }),
+		} as any;
+
+		getSessionOutput(session, config, state, {
+			lines: Number.NaN,
+			maxChars: Number.POSITIVE_INFINITY,
+		});
+
+		expect(captured).toMatchObject({ lines: 20, maxChars: 5120 });
+	});
+
 	it("rate limits repeated queries until enough time has passed", () => {
 		const state = createSessionQueryState();
 		const session = makeSession();


### PR DESCRIPTION
This is a scoped TypeScript quality cleanup pass.

It keeps parsed config as `unknown` until the root shape is validated, omits optional defaults instead of setting `undefined`, rejects non-finite numeric config/query values at the boundary, derives monitor literals from the shared event contract, and removes unnecessary assertions around PTY serialization and monitor callback promises.

Verification:
- `npm run typecheck`
- `npx vitest run --silent` — 17 files / 78 tests passing

Fresh read-only review found no reachable issues.
