### PR TITLE
Fix fish Primary DA startup timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ All notable changes to the `pi-interactive-shell` extension will be documented i
 - Compiled monitor config is now a discriminated union on strategy, making `fileWatch` presence impossible to misuse for non-file-watch strategies.
 - `/dismiss` selection no longer treats an unmatched select label as "dismiss all".
 
+### Fixed
+- Respond to fish's Primary Device Attribute query so interactive fish sessions do not wait for the 10-second terminal capability timeout (#21, reported by @PaulGrandperrin).
+
 ## [0.13.0] - 2026-04-23
 
 ### Changed

--- a/pty-protocol.ts
+++ b/pty-protocol.ts
@@ -1,33 +1,35 @@
-// DSR (Device Status Report) - cursor position query: ESC[6n or ESC[?6n
-const DSR_PATTERN = /\x1b\[\??6n/g;
+// PTY control queries emitted by terminal applications.
+// Cursor position DSR: ESC[6n or ESC[?6n. Primary DA: ESC[c or ESC[0c.
+const DEVICE_QUERY_PATTERN = /\x1b\[(\??6n|0?c)/g;
 
-/** Result of splitting PTY output around device-status-report cursor queries. */
-export interface DsrSplit {
-	segments: Array<{ text: string; dsrAfter: boolean }>;
-	hasDsr: boolean;
+export type DeviceQuery = "cursor-position" | "primary-device-attributes";
+
+/** Result of splitting PTY output around terminal queries that require a response. */
+export interface DeviceQuerySplit {
+	segments: Array<{ text: string; queryAfter: DeviceQuery }>;
+	trailingText: string;
+	hasQuery: boolean;
 }
 
-export function splitAroundDsr(input: string): DsrSplit {
-	const segments: Array<{ text: string; dsrAfter: boolean }> = [];
+export function splitAroundDeviceQueries(input: string): DeviceQuerySplit {
+	const segments: Array<{ text: string; queryAfter: DeviceQuery }> = [];
 	let lastIndex = 0;
-	let hasDsr = false;
-	const regex = new RegExp(DSR_PATTERN.source, "g");
+	const regex = new RegExp(DEVICE_QUERY_PATTERN.source, "g");
 	let match: RegExpExecArray | null;
 	while ((match = regex.exec(input)) !== null) {
-		hasDsr = true;
-		if (match.index > lastIndex) {
-			segments.push({ text: input.slice(lastIndex, match.index), dsrAfter: true });
-		} else {
-			segments.push({ text: "", dsrAfter: true });
-		}
+		segments.push({
+			text: input.slice(lastIndex, match.index),
+			queryAfter: match[1].endsWith("c") ? "primary-device-attributes" : "cursor-position",
+		});
 		lastIndex = match.index + match[0].length;
 	}
-	if (lastIndex < input.length) {
-		segments.push({ text: input.slice(lastIndex), dsrAfter: false });
-	}
-	return { segments, hasDsr };
+	return { segments, trailingText: input.slice(lastIndex), hasQuery: segments.length > 0 };
 }
 
 export function buildCursorPositionResponse(row = 1, col = 1): string {
 	return `\x1b[${row};${col}R`;
+}
+
+export function buildPrimaryDeviceAttributesResponse(): string {
+	return "\x1b[?1;2c";
 }

--- a/pty-session.ts
+++ b/pty-session.ts
@@ -4,7 +4,11 @@ import type { IBufferCell, Terminal as XtermTerminal } from "@xterm/headless";
 import xterm from "@xterm/headless";
 import { SerializeAddon } from "@xterm/addon-serialize";
 import { sliceLogOutput, trimRawOutput } from "./pty-log.ts";
-import { splitAroundDsr, buildCursorPositionResponse } from "./pty-protocol.ts";
+import {
+	buildCursorPositionResponse,
+	buildPrimaryDeviceAttributesResponse,
+	splitAroundDeviceQueries,
+} from "./pty-protocol.ts";
 
 const Terminal = xterm.Terminal;
 
@@ -207,13 +211,10 @@ export class PtyTerminalSession {
 
 		this.ptyProcess.onData((data) => {
 			const chunk = typeof data === "string" ? data : data.toString("utf8");
-			// Handle DSR (Device Status Report) cursor position queries
-			// TUI apps send ESC[6n or ESC[?6n expecting ESC[row;colR response
-			// We must process in order: write text to xterm, THEN respond to DSR
-			const { segments, hasDsr } = splitAroundDsr(chunk);
+			// Handle terminal queries in order: write preceding text to xterm, then respond.
+			const { segments, trailingText, hasQuery } = splitAroundDeviceQueries(chunk);
 
-			if (!hasDsr) {
-				// Fast path: no DSR in data
+			if (!hasQuery) {
 				this.writeQueue.enqueue(async () => {
 					this.rawOutput += chunk;
 					this.trimRawOutputIfNeeded();
@@ -223,7 +224,6 @@ export class PtyTerminalSession {
 					this.notifyDataListeners(chunk);
 				});
 			} else {
-				// Process each segment in order, responding to DSR after writing preceding text
 				for (const segment of segments) {
 					this.writeQueue.enqueue(async () => {
 						if (segment.text) {
@@ -234,12 +234,22 @@ export class PtyTerminalSession {
 							});
 							this.notifyDataListeners(segment.text);
 						}
-						// If there was a DSR after this segment, respond with current cursor position
-						if (segment.dsrAfter) {
+						if (segment.queryAfter === "cursor-position") {
 							const buffer = this.xterm.buffer.active;
-							const response = buildCursorPositionResponse(buffer.cursorY + 1, buffer.cursorX + 1);
-							this.ptyProcess.write(response);
+							this.ptyProcess.write(buildCursorPositionResponse(buffer.cursorY + 1, buffer.cursorX + 1));
+						} else {
+							this.ptyProcess.write(buildPrimaryDeviceAttributesResponse());
 						}
+					});
+				}
+				if (trailingText) {
+					this.writeQueue.enqueue(async () => {
+						this.rawOutput += trailingText;
+						this.trimRawOutputIfNeeded();
+						await new Promise<void>((resolve) => {
+							this.xterm.write(trailingText, () => resolve());
+						});
+						this.notifyDataListeners(trailingText);
 					});
 				}
 			}

--- a/tests/pty-protocol.test.ts
+++ b/tests/pty-protocol.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import {
+	buildCursorPositionResponse,
+	buildPrimaryDeviceAttributesResponse,
+	splitAroundDeviceQueries,
+} from "../pty-protocol.ts";
+
+describe("pty protocol queries", () => {
+	it("splits cursor DSR and Primary DA queries in order", () => {
+		expect(splitAroundDeviceQueries(`a\x1b[0cb\x1b[6nc`)).toEqual({
+			segments: [
+				{ text: "a", queryAfter: "primary-device-attributes" },
+				{ text: "b", queryAfter: "cursor-position" },
+			],
+			trailingText: "c",
+			hasQuery: true,
+		});
+	});
+
+	it("recognizes implicit Primary DA and private cursor DSR forms", () => {
+		expect(splitAroundDeviceQueries("\x1b[c\x1b[?6n")).toEqual({
+			segments: [
+				{ text: "", queryAfter: "primary-device-attributes" },
+				{ text: "", queryAfter: "cursor-position" },
+			],
+			trailingText: "",
+			hasQuery: true,
+		});
+	});
+
+	it("builds terminal responses expected by shells", () => {
+		expect(buildCursorPositionResponse(12, 34)).toBe("\x1b[12;34R");
+		expect(buildPrimaryDeviceAttributesResponse()).toMatch(/^\x1b\[\?.*c$/);
+	});
+});


### PR DESCRIPTION
Fixes #21.

This teaches the PTY protocol layer to recognize fish's Primary Device Attribute queries (`ESC[0c`, plus the implicit `ESC[c` form) alongside the existing cursor-position DSR handling. The session now responds with an xterm-compatible Primary DA response while preserving ordered text writes and keeping query bytes out of terminal output.

Credit to @PaulGrandperrin for the report and workaround.

Validation:
- `npm run typecheck`
- `npx vitest run tests/pty-protocol.test.ts --silent`
- `npx vitest run --silent` — 18 files / 81 tests passing

Fresh read-only review found no reachable issues. There are no `.github/workflows` files in this repository, so no GitHub Actions workflow check is expected.
