### PR TITLE
fix: clarify quiet dispatch completion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to the `pi-interactive-shell` extension will be documented i
 
 ## [Unreleased]
 
+### Fixed
++- Identify dispatch sessions that auto-close after quiet separately from user-killed sessions, and clarify isolated-worktree guidance for unattended coding-agent runs.
+
 ## [0.14.0] - 2026-07-29
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ interactive_shell({ spawn: { agent: "claude", worktree: true }, mode: "hands-fre
 interactive_shell({ spawn: { mode: "fork" }, mode: "interactive" })
 ```
 
-Structured `spawn` uses the same resolver and config defaults as the user-facing `/spawn` command. Raw `command` is still supported for arbitrary CLIs and custom launch strings.
+Structured `spawn` uses the same resolver and config defaults as the user-facing `/spawn` command. Raw `command` is still supported for arbitrary CLIs and custom launch strings. For unattended coding-agent work in a repository, prefer structured `spawn` with `worktree: true` or set an explicitly isolated `cwd`; a raw agent command runs in the supplied working directory and can change its Git state.
 
 Any extra key you add under `spawn.commands` becomes a first-class spawn agent, usable as `spawn: { agent: "aider" }` and `/spawn aider`, with its own `spawn.defaultArgs` entry, worktree support, and prompt passthrough. `fork` stays Pi-only. Agent names must start with a letter or digit, may contain letters, digits, `.`, `_`, and `-`, and cannot be `fresh` or `fork`, because those are `/spawn` keywords.
 
@@ -153,7 +153,7 @@ Attach to review full output: interactive_shell({ attach: "calm-reef" })
 
 The notification includes a brief tail (last 5 lines) and a reattach instruction. The PTY is preserved for 5 minutes so the agent can attach to review full scrollback.
 
-Dispatch defaults `autoExitOnQuiet: true` — the session gets a 15s startup grace period, then is killed after output goes silent (8s by default), which signals completion for task-oriented subagents. Tune the grace period with `handsFree: { gracePeriod: 60000 }` or opt out entirely with `handsFree: { autoExitOnQuiet: false }`.
+Dispatch defaults `autoExitOnQuiet: true` — the session gets a 15s startup grace period, then auto-closes after output goes silent (8s by default). The completion notification identifies this as a quiet auto-close, not a user kill. Tune the grace period with `handsFree: { gracePeriod: 60000 }` or opt out entirely with `handsFree: { autoExitOnQuiet: false }`.
 
 The overlay still shows for the user, who can Ctrl+T to transfer output, Ctrl+B to background, take over by typing, or Ctrl+Q for more options. `Ctrl+G` only becomes meaningful after the user has taken over a monitored hands-free or dispatch session.
 

--- a/headless-monitor.ts
+++ b/headless-monitor.ts
@@ -44,6 +44,8 @@ export interface HeadlessCompletionInfo {
 	signal?: number;
 	timedOut?: boolean;
 	cancelled?: boolean;
+	/** The monitor ended an otherwise idle session after the configured quiet threshold. */
+	autoClosedOnQuiet?: boolean;
 	completionOutput?: {
 		lines: string[];
 		totalLines: number;
@@ -266,7 +268,7 @@ export class HeadlessDispatchMonitor {
 					return;
 				}
 				this.session.kill();
-				this.handleCompletion(null, undefined, false, true);
+				this.handleCompletion(null, undefined, false, true, true);
 			}
 		}, this.options.quietThreshold);
 	}
@@ -296,7 +298,7 @@ export class HeadlessDispatchMonitor {
 		}
 	}
 
-	private handleCompletion(exitCode: number | null, signal?: number, timedOut?: boolean, cancelled?: boolean): void {
+	private handleCompletion(exitCode: number | null, signal?: number, timedOut?: boolean, cancelled?: boolean, autoClosedOnQuiet?: boolean): void {
 		if (this._disposed) return;
 		if (this.options.monitor?.strategy !== "poll-diff" && this.options.onMonitorEvent) {
 			this.processMonitorData("", true);
@@ -312,7 +314,14 @@ export class HeadlessDispatchMonitor {
 		}
 
 		const completionOutput = this.captureOutput();
-		const info: HeadlessCompletionInfo = { exitCode, signal, timedOut, cancelled, completionOutput };
+		const info: HeadlessCompletionInfo = {
+			exitCode,
+			signal,
+			timedOut,
+			cancelled,
+			...(autoClosedOnQuiet ? { autoClosedOnQuiet: true } : {}),
+			completionOutput,
+		};
 		this.result = info;
 		this.triggerCompleteCallbacks();
 		this.onComplete(info);

--- a/notification-utils.ts
+++ b/notification-utils.ts
@@ -137,6 +137,7 @@ export function buildIdlePromptWarning(command: string, reason: string | undefin
 
 function buildDispatchStatusLine(sessionId: string, info: HeadlessCompletionInfo, duration: string): string {
 	if (info.timedOut) return `Session ${sessionId} timed out (${duration}).`;
+	if (info.autoClosedOnQuiet) return `Session ${sessionId} auto-closed after quiet (${duration}).`;
 	if (info.cancelled) return `Session ${sessionId} was killed (${duration}).`;
 	if (info.exitCode === 0) return `Session ${sessionId} completed successfully (${duration}).`;
 	return `Session ${sessionId} exited with code ${info.exitCode} (${duration}).`;

--- a/skills/pi-interactive-shell/SKILL.md
+++ b/skills/pi-interactive-shell/SKILL.md
@@ -58,7 +58,7 @@ Pi is the default because it's already available, has the same capabilities, and
 
 ## Structured Spawn and `/spawn`
 
-For Pi, Codex, Claude, and Cursor, prefer structured `spawn` params when you want the extension's shared resolver, config defaults, native startup prompt forms, or Pi-only fork/worktree behavior:
+For Pi, Codex, Claude, and Cursor, prefer structured `spawn` params when you want the extension's shared resolver, config defaults, native startup prompt forms, or Pi-only fork/worktree behavior. For unattended coding-agent work in a repository, use `worktree: true` or an explicitly isolated `cwd`; raw commands run in their supplied working directory and can change its Git state:
 
 ```typescript
 interactive_shell({ spawn: { agent: "pi" }, mode: "interactive" })
@@ -112,7 +112,7 @@ interactive_shell({
 // → Do other work. When session completes, you receive notification with output.
 ```
 
-Dispatch defaults `autoExitOnQuiet: true`. The agent can still query the sessionId if needed, but doesn't have to.
+Dispatch defaults `autoExitOnQuiet: true`. A quiet TUI auto-closes after the threshold and reports that completion reason separately from a user kill. The agent can still query the sessionId if needed, but doesn't have to.
 
 For fire-and-forget delegated runs (including QA-style delegated checks), prefer dispatch as the default mode.
 

--- a/tests/config-and-docs.test.ts
+++ b/tests/config-and-docs.test.ts
@@ -134,6 +134,9 @@ describe("config + docs parity", () => {
 		expect(readme).toContain(`"handsFreeQuietThreshold": ${defaults.handsFreeQuietThreshold}`);
 		expect(readme).toContain(`"autoExitGracePeriod": ${defaults.autoExitGracePeriod}`);
 		expect(readme).toContain(`Dispatch defaults \`autoExitOnQuiet: true\` — the session gets a 15s startup grace period`);
+		expect(readme).toContain("The completion notification identifies this as a quiet auto-close, not a user kill.");
+		expect(skill).toContain("reports that completion reason separately from a user kill");
+		expect(toolSchema).toContain("reports that completion reason separately from a user kill");
 		expect(readme).toContain('submit: true');
 		expect(readme).toContain('raw `input` only types text. It does not submit the prompt.');
 		expect(skill).toContain("~8s of quiet");

--- a/tests/headless-monitor.test.ts
+++ b/tests/headless-monitor.test.ts
@@ -87,7 +87,10 @@ describe("HeadlessDispatchMonitor", () => {
 		session.emitData("\u001b[2K\u001b[1G");
 		vi.advanceTimersByTime(1000);
 		expect(session.kill).toHaveBeenCalledTimes(1);
-		expect(onComplete).toHaveBeenCalledTimes(1);
+		expect(onComplete).toHaveBeenCalledWith(expect.objectContaining({
+			cancelled: true,
+			autoClosedOnQuiet: true,
+		}));
 	});
 
 	it("respects startup grace period and preserves explicit startedAt", () => {

--- a/tests/notification-utils.test.ts
+++ b/tests/notification-utils.test.ts
@@ -16,7 +16,17 @@ describe("notification utilities", () => {
 		expect(text).toContain('Attach to review full output: interactive_shell({ attach: "calm-reef" })');
 	});
 
-	it("formats cancelled dispatch notifications as killed", () => {
+	it("distinguishes quiet auto-close from a killed dispatch session", () => {
+		const text = buildDispatchNotification("calm-reef", {
+			exitCode: null,
+			cancelled: true,
+			autoClosedOnQuiet: true,
+		}, "30s");
+		expect(text).toContain("Session calm-reef auto-closed after quiet (30s).");
+		expect(text).not.toContain("was killed");
+	});
+
+	it("formats explicitly cancelled dispatch notifications as killed", () => {
 		const text = buildDispatchNotification("calm-reef", {
 			exitCode: null,
 			cancelled: true,

--- a/tool-schema.ts
+++ b/tool-schema.ts
@@ -18,6 +18,7 @@ MODES:
 RECOMMENDED DEFAULT FOR DELEGATED TASKS:
 - For fire-and-forget delegations and QA-style checks, prefer mode="dispatch".
 - Dispatch is the safest choice when the agent should continue immediately and be notified automatically on completion.
+- For unattended coding-agent work in a repository, prefer structured spawn with \`worktree: true\` or an explicitly isolated \`cwd\`; raw commands run in their supplied working directory and can change its Git state.
 
 The user will see the process in an overlay. They can:
 - Watch output in real-time
@@ -91,7 +92,7 @@ Workflow:
 2. Do other work - no polling needed
 3. When complete, you receive a notification with the session output
 
-Dispatch defaults autoExitOnQuiet to true (opt-out with handsFree.autoExitOnQuiet: false).
+Dispatch defaults autoExitOnQuiet to true (opt-out with handsFree.autoExitOnQuiet: false). A quiet TUI auto-closes after the threshold and reports that completion reason separately from a user kill.
 You can still query with sessionId if needed, but it's not required.
 
 BACKGROUND DISPATCH (HEADLESS):


### PR DESCRIPTION
Closes #24.

Distinguishes quiet auto-close from user kills in dispatch completion metadata and notifications. Adds focused coverage plus safer isolated-worktree guidance for unattended coding-agent dispatch.