### PR TITLE
fix: ignore empty spawn placeholders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@ All notable changes to the `pi-interactive-shell` extension will be documented i
 ## [Unreleased]
 
 ### Fixed
-+- Identify dispatch sessions that auto-close after quiet separately from user-killed sessions, and clarify isolated-worktree guidance for unattended coding-agent runs.
+- Identify dispatch sessions that auto-close after quiet separately from user-killed sessions, and clarify isolated-worktree guidance for unattended coding-agent runs.
+- Ignore schema-generated empty `spawn` placeholders on raw `interactive_shell` commands so serialized optional fields do not block command launches (#26, by @dathtd119).
 
 ## [0.14.0] - 2026-07-29
 

--- a/index.ts
+++ b/index.ts
@@ -18,7 +18,7 @@ import type {
 import { sessionManager, generateSessionId } from "./session-manager.ts";
 import { loadConfig } from "./config.ts";
 import type { InteractiveShellConfig } from "./config.ts";
-import { parseSpawnArgs, resolveSpawn, type SpawnRequest } from "./spawn.ts";
+import { normalizeSpawnRequest, parseSpawnArgs, resolveSpawn, type SpawnRequest } from "./spawn.ts";
 import { translateInput } from "./key-encoding.ts";
 import { TOOL_NAME, TOOL_LABEL, TOOL_DESCRIPTION, toolParameters, type ToolParams } from "./tool-schema.ts";
 import { HeadlessDispatchMonitor } from "./headless-monitor.ts";
@@ -1141,14 +1141,15 @@ export default function interactiveShellExtension(pi: ExtensionAPI) {
 			const effectiveInput = hasStructuredInput
 				? { text: input, keys: inputKeys, hex: inputHex, paste: inputPaste }
 				: input;
+			const normalizedSpawn = normalizeSpawnRequest(spawn);
 
-			if (spawn && command) {
+			if (normalizedSpawn && command) {
 				return {
 					content: [{ type: "text", text: "Use either 'command' or 'spawn', not both." }],
 					isError: true,
 				};
 			}
-			if (spawn && (sessionId || attach || listBackground || dismissBackground || monitorEvents || monitorStatus)) {
+			if (normalizedSpawn && (sessionId || attach || listBackground || dismissBackground || monitorEvents || monitorStatus)) {
 				return {
 					content: [{ type: "text", text: "'spawn' is only valid when starting a new session." }],
 					isError: true,
@@ -1624,7 +1625,7 @@ export default function interactiveShellExtension(pi: ExtensionAPI) {
 
 			// ── Branch 4: Start new session ──
 			const allowsGeneratedCommand = mode === "monitor" && monitor?.strategy === "file-watch";
-			if (!command && !spawn && !allowsGeneratedCommand) {
+			if (!command && !normalizedSpawn && !allowsGeneratedCommand) {
 				return {
 					content: [{ type: "text", text: "One of 'command', 'spawn', 'sessionId', 'attach', 'listBackground', or 'dismissBackground' is required." }],
 					isError: true,
@@ -1633,7 +1634,7 @@ export default function interactiveShellExtension(pi: ExtensionAPI) {
 			return startNewSession({
 				ctx,
 				command,
-				spawn,
+				spawn: normalizedSpawn,
 				cwd,
 				name,
 				reason,

--- a/index.ts
+++ b/index.ts
@@ -18,7 +18,7 @@ import type {
 import { sessionManager, generateSessionId } from "./session-manager.ts";
 import { loadConfig } from "./config.ts";
 import type { InteractiveShellConfig } from "./config.ts";
-import { normalizeSpawnRequest, parseSpawnArgs, resolveSpawn, type SpawnRequest } from "./spawn.ts";
+import { isEmptySpawnPlaceholder, normalizeSpawnRequest, parseSpawnArgs, resolveSpawn, type SpawnRequest } from "./spawn.ts";
 import { translateInput } from "./key-encoding.ts";
 import { TOOL_NAME, TOOL_LABEL, TOOL_DESCRIPTION, toolParameters, type ToolParams } from "./tool-schema.ts";
 import { HeadlessDispatchMonitor } from "./headless-monitor.ts";
@@ -1142,14 +1142,17 @@ export default function interactiveShellExtension(pi: ExtensionAPI) {
 				? { text: input, keys: inputKeys, hex: inputHex, paste: inputPaste }
 				: input;
 			const normalizedSpawn = normalizeSpawnRequest(spawn);
+			const spawnForAction = command && isEmptySpawnPlaceholder(spawn)
+				? undefined
+				: normalizedSpawn;
 
-			if (normalizedSpawn && command) {
+			if (spawnForAction && command) {
 				return {
 					content: [{ type: "text", text: "Use either 'command' or 'spawn', not both." }],
 					isError: true,
 				};
 			}
-			if (normalizedSpawn && (sessionId || attach || listBackground || dismissBackground || monitorEvents || monitorStatus)) {
+			if (spawnForAction && (sessionId || attach || listBackground || dismissBackground || monitorEvents || monitorStatus)) {
 				return {
 					content: [{ type: "text", text: "'spawn' is only valid when starting a new session." }],
 					isError: true,
@@ -1625,7 +1628,7 @@ export default function interactiveShellExtension(pi: ExtensionAPI) {
 
 			// ── Branch 4: Start new session ──
 			const allowsGeneratedCommand = mode === "monitor" && monitor?.strategy === "file-watch";
-			if (!command && !normalizedSpawn && !allowsGeneratedCommand) {
+			if (!command && !spawnForAction && !allowsGeneratedCommand) {
 				return {
 					content: [{ type: "text", text: "One of 'command', 'spawn', 'sessionId', 'attach', 'listBackground', or 'dismissBackground' is required." }],
 					isError: true,
@@ -1634,7 +1637,7 @@ export default function interactiveShellExtension(pi: ExtensionAPI) {
 			return startNewSession({
 				ctx,
 				command,
-				spawn: normalizedSpawn,
+				spawn: spawnForAction,
 				cwd,
 				name,
 				reason,

--- a/spawn.ts
+++ b/spawn.ts
@@ -19,25 +19,34 @@ export interface ParsedSpawnArgs {
 }
 
 /**
- * Treat schema-generated empty spawn objects as absent.
+ * Remove string and mode defaults that schema-driven callers may serialize.
  *
- * Some tool callers serialize every optional field, producing a shape such as
- * `{ agent: "", mode: "fresh", worktree: false, prompt: "" }` for a raw
- * command launch. That object must not conflict with `command`. Deliberate
- * spawn behavior remains meaningful when it selects an agent, forks, creates
- * a worktree, or carries non-blank prompt text.
+ * The returned object always preserves the presence of a spawn request, which
+ * keeps `spawn: {}` and `worktree: false` valid standalone requests. Raw
+ * command handling may separately identify a fully-default placeholder.
  */
 export function normalizeSpawnRequest(request: SpawnRequest | undefined): SpawnRequest | undefined {
 	if (!request) return undefined;
 
-	const agent = request.agent?.trim();
-	const prompt = request.prompt?.trim();
-	const isMeaningful = Boolean(agent)
-		|| request.mode === "fork"
-		|| request.worktree === true
-		|| Boolean(prompt);
+	const agent = request.agent?.trim() || undefined;
+	const prompt = request.prompt?.trim() || undefined;
+	const mode = request.mode === "fresh" ? undefined : request.mode;
 
-	return isMeaningful ? request : undefined;
+	return {
+		...(agent === undefined ? {} : { agent }),
+		...(mode === undefined ? {} : { mode }),
+		...(request.worktree === undefined ? {} : { worktree: request.worktree }),
+		...(prompt === undefined ? {} : { prompt }),
+	};
+}
+
+/** True only for the complete default shape emitted beside a raw command. */
+export function isEmptySpawnPlaceholder(request: SpawnRequest | undefined): boolean {
+	return request !== undefined
+		&& (request.agent?.trim() ?? "") === ""
+		&& (request.prompt?.trim() ?? "") === ""
+		&& (request.mode === undefined || request.mode === "fresh")
+		&& (request.worktree === undefined || request.worktree === false);
 }
 
 export interface ResolvedSpawn {

--- a/spawn.ts
+++ b/spawn.ts
@@ -18,6 +18,28 @@ export interface ParsedSpawnArgs {
 	monitorMode?: SpawnMonitorMode;
 }
 
+/**
+ * Treat schema-generated empty spawn objects as absent.
+ *
+ * Some tool callers serialize every optional field, producing a shape such as
+ * `{ agent: "", mode: "fresh", worktree: false, prompt: "" }` for a raw
+ * command launch. That object must not conflict with `command`. Deliberate
+ * spawn behavior remains meaningful when it selects an agent, forks, creates
+ * a worktree, or carries non-blank prompt text.
+ */
+export function normalizeSpawnRequest(request: SpawnRequest | undefined): SpawnRequest | undefined {
+	if (!request) return undefined;
+
+	const agent = request.agent?.trim();
+	const prompt = request.prompt?.trim();
+	const isMeaningful = Boolean(agent)
+		|| request.mode === "fork"
+		|| request.worktree === true
+		|| Boolean(prompt);
+
+	return isMeaningful ? request : undefined;
+}
+
 export interface ResolvedSpawn {
 	agent: SpawnAgent;
 	mode: SpawnMode;

--- a/tests/spawn-command.test.ts
+++ b/tests/spawn-command.test.ts
@@ -266,6 +266,43 @@ describe("/spawn command, shortcut, and tool spawn", () => {
 		expect(harness.getLastOverlayOptions()).toMatchObject({ command: "printf placeholder-ok" });
 	});
 
+	it("interactive_shell preserves standalone default spawn and explicit false worktree", async () => {
+		const defaultHarness = await setupExtensionHarness({ spawn: { defaultAgent: "codex" } });
+		const defaultTool = defaultHarness.getTool();
+		expect(defaultTool).toBeTruthy();
+
+		const defaultResult = await defaultTool!.execute("call-1", {
+			spawn: {},
+			mode: "interactive",
+		}, undefined, undefined, defaultHarness.ctx as any);
+		expect(defaultResult.isError).not.toBe(true);
+		expect(defaultHarness.getLastOverlayOptions()).toMatchObject({ command: "codex" });
+
+		const falseOverrideHarness = await setupExtensionHarness({ spawn: { defaultAgent: "codex", worktree: true } });
+		const falseOverrideTool = falseOverrideHarness.getTool();
+		expect(falseOverrideTool).toBeTruthy();
+		const falseOverrideResult = await falseOverrideTool!.execute("call-2", {
+			spawn: { worktree: false },
+			mode: "interactive",
+		}, undefined, undefined, falseOverrideHarness.ctx as any);
+		expect(falseOverrideResult.isError).not.toBe(true);
+		expect(falseOverrideHarness.getLastOverlayOptions()).toMatchObject({ command: "codex", cwd: "/tmp/project" });
+	});
+
+	it("interactive_shell accepts serialized intentional spawn requests", async () => {
+		const harness = await setupExtensionHarness();
+		const tool = harness.getTool();
+		expect(tool).toBeTruthy();
+
+		const result = await tool!.execute("call-1", {
+			spawn: { agent: "codex", mode: "fresh", worktree: false, prompt: "" },
+			mode: "interactive",
+		}, undefined, undefined, harness.ctx as any);
+
+		expect(result.isError).not.toBe(true);
+		expect(harness.getLastOverlayOptions()).toMatchObject({ command: "codex" });
+	});
+
 	it("interactive_shell structured spawn uses the shared resolver", async () => {
 		const harness = await setupExtensionHarness({
 			spawn: { defaultAgent: "pi", commands: { codex: "/opt/codex/bin/codex" } },

--- a/tests/spawn-command.test.ts
+++ b/tests/spawn-command.test.ts
@@ -251,6 +251,21 @@ describe("/spawn command, shortcut, and tool spawn", () => {
 		expect(harness.getLastOverlayOptions()).toMatchObject({ command: "claude" });
 	});
 
+	it("interactive_shell accepts raw commands beside empty spawn placeholders", async () => {
+		const harness = await setupExtensionHarness();
+		const tool = harness.getTool();
+		expect(tool).toBeTruthy();
+
+		const result = await tool!.execute("call-1", {
+			command: "printf placeholder-ok",
+			spawn: { agent: "", mode: "fresh", worktree: false, prompt: "" },
+			mode: "interactive",
+		}, undefined, undefined, harness.ctx as any);
+
+		expect(result.isError).not.toBe(true);
+		expect(harness.getLastOverlayOptions()).toMatchObject({ command: "printf placeholder-ok" });
+	});
+
 	it("interactive_shell structured spawn uses the shared resolver", async () => {
 		const harness = await setupExtensionHarness({
 			spawn: { defaultAgent: "pi", commands: { codex: "/opt/codex/bin/codex" } },

--- a/tests/spawn.test.ts
+++ b/tests/spawn.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { InteractiveShellConfig } from "../config.ts";
+import type { SpawnRequest } from "../spawn.ts";
 
 const config: InteractiveShellConfig = {
 	exitAutoCloseDelay: 10,
@@ -195,6 +196,24 @@ describe("spawn helpers", () => {
 				worktreePath: undefined,
 			},
 		});
+	});
+
+	it("normalizes schema-generated empty spawn placeholders", async () => {
+		const { normalizeSpawnRequest } = await import("../spawn.ts");
+		expect(normalizeSpawnRequest(undefined)).toBeUndefined();
+		expect(normalizeSpawnRequest({})).toBeUndefined();
+		expect(normalizeSpawnRequest({ agent: "", mode: "fresh", worktree: false, prompt: "" })).toBeUndefined();
+		expect(normalizeSpawnRequest({ agent: "  ", mode: "fresh", worktree: false, prompt: " \t " })).toBeUndefined();
+
+		const intentionalRequests: SpawnRequest[] = [
+			{ agent: "pi" },
+			{ mode: "fork" },
+			{ worktree: true },
+			{ prompt: "review diffs" },
+		];
+		for (const request of intentionalRequests) {
+			expect(normalizeSpawnRequest(request)).toBe(request);
+		}
 	});
 
 	it("rejects empty structured spawn prompts", async () => {

--- a/tests/spawn.test.ts
+++ b/tests/spawn.test.ts
@@ -198,22 +198,21 @@ describe("spawn helpers", () => {
 		});
 	});
 
-	it("normalizes schema-generated empty spawn placeholders", async () => {
-		const { normalizeSpawnRequest } = await import("../spawn.ts");
+	it("normalizes serialized spawn fields without erasing standalone requests", async () => {
+		const { isEmptySpawnPlaceholder, normalizeSpawnRequest } = await import("../spawn.ts");
 		expect(normalizeSpawnRequest(undefined)).toBeUndefined();
-		expect(normalizeSpawnRequest({})).toBeUndefined();
-		expect(normalizeSpawnRequest({ agent: "", mode: "fresh", worktree: false, prompt: "" })).toBeUndefined();
-		expect(normalizeSpawnRequest({ agent: "  ", mode: "fresh", worktree: false, prompt: " \t " })).toBeUndefined();
+		expect(normalizeSpawnRequest({})).toEqual({});
+		expect(normalizeSpawnRequest({ agent: "", mode: "fresh", worktree: false, prompt: "" })).toEqual({ worktree: false });
+		expect(normalizeSpawnRequest({ agent: "  ", mode: "fresh", worktree: false, prompt: " \t " })).toEqual({ worktree: false });
+		expect(normalizeSpawnRequest({ agent: "codex", mode: "fresh", worktree: false, prompt: "" })).toEqual({ agent: "codex", worktree: false });
+		expect(normalizeSpawnRequest({ agent: "", mode: "fresh", worktree: false, prompt: "review diffs" })).toEqual({ worktree: false, prompt: "review diffs" });
 
-		const intentionalRequests: SpawnRequest[] = [
-			{ agent: "pi" },
-			{ mode: "fork" },
-			{ worktree: true },
-			{ prompt: "review diffs" },
-		];
-		for (const request of intentionalRequests) {
-			expect(normalizeSpawnRequest(request)).toBe(request);
-		}
+		expect(isEmptySpawnPlaceholder({ agent: "", mode: "fresh", worktree: false, prompt: "" })).toBe(true);
+		expect(isEmptySpawnPlaceholder({})).toBe(true);
+		expect(isEmptySpawnPlaceholder({ worktree: false })).toBe(true);
+		expect(isEmptySpawnPlaceholder({ agent: "pi", mode: "fresh", worktree: false, prompt: "" })).toBe(false);
+		expect(isEmptySpawnPlaceholder({ worktree: true })).toBe(false);
+		expect(isEmptySpawnPlaceholder({ prompt: "review diffs" })).toBe(false);
 	});
 
 	it("rejects empty structured spawn prompts", async () => {


### PR DESCRIPTION
## Summary
- treat schema-generated empty `spawn` objects as absent
- preserve intentional structured spawn requests and raw command/spawn conflict protection
- add helper and tool-level regression coverage

## Reproduction
- Some callers serialize optional tool fields, sending a raw `command` together with `spawn: { agent: "", mode: "fresh", worktree: false, prompt: "" }`. 
- The old truthiness check rejected this with `Use either 'command' or 'spawn', not both.`

## Verification
- `npm test` - 84 passing
- `npm run typecheck`
- fresh local Pi process reached an `interactive_shell` raw-command session instead of returning the conflict