### PR TITLE
fix: keep interactive shell sessions controllable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to the `pi-interactive-shell` extension will be documented i
 ### Fixed
 - Identify dispatch sessions that auto-close after quiet separately from user-killed sessions, and clarify isolated-worktree guidance for unattended coding-agent runs.
 - Ignore schema-generated empty `spawn` placeholders on raw `interactive_shell` commands so serialized optional fields do not block command launches (#26, by @dathtd119).
+- Return a stable controllable `sessionId` for interactive shell starts so agents can submit input before backgrounding or reattaching (#28).
 
 ## [0.14.0] - 2026-07-29
 

--- a/README.md
+++ b/README.md
@@ -38,14 +38,14 @@ The `interactive-shell` skill is automatically symlinked to `~/.pi/agent/skills/
 
 | Mode | Agent waits? | How output reaches agent | Best for |
 |---|---|---|---|
-| **Interactive** (default) | Yes — blocks until exit | Tool return value | Editors, REPLs, SSH — when you need the result now |
-| **Hands-free** | No | Poll with `sessionId` | Dev servers, builds — when you want to watch progress and send follow-up commands |
+| **Interactive** (default) | No | Stable `sessionId` for input/status | Editors, REPLs, SSH — when the agent or user will drive the shell |
+| **Hands-free** | No | Poll with `sessionId` plus quiet updates | Dev servers, builds — when you want to watch progress and send follow-up commands |
 | **Dispatch** | No | Notification on completion via `triggerTurn` | Delegating tasks to subagents — fire and forget |
 | **Monitor** | No | Notification on structured monitor trigger events | Watchers, logs, tests, and state checks — wake only when something specific happens |
 
-**Interactive** — The overlay opens, user controls the session, agent waits for it to close. Use for editors (`vim`), database shells (`psql`), or any task where the agent needs the final result immediately.
+**Interactive** — The overlay opens and returns a stable `sessionId` immediately. The user can type directly, and the agent can send `input` with `submit: true`, check status, or background the same id. Use for editors (`vim`), database shells (`psql`), SSH, or manual CLI flows where the next step is still interactive.
 
-**Hands-free** — The overlay opens but returns immediately. The agent polls periodically with `sessionId` to check status and get new output. Good for long-running builds or dev servers where you want to react mid-flight (send input, check logs, kill when ready).
+**Hands-free** — The overlay opens and returns a stable `sessionId` immediately. The agent polls periodically with `sessionId` and also receives quiet/output updates. Good for long-running builds or dev servers where you want to react mid-flight (send input, check logs, kill when ready).
 
 **Dispatch** — Returns immediately. No polling. The agent gets woken up via `triggerTurn` only when the session completes (natural exit, timeout, quiet detection, or user kill). The notification includes a tail of the output. This is the default for delegating work to subagents. Add `background: true` to skip the overlay entirely.
 
@@ -98,7 +98,7 @@ interactive_shell({ command: 'psql -d mydb' })
 interactive_shell({ command: 'ssh user@server' })
 ```
 
-The agent's turn is blocked until the overlay closes. User controls the session directly.
+The tool returns a stable `sessionId` immediately. The agent can drive the same shell with `interactive_shell({ sessionId, input, submit: true })`, while the user can still type directly in the focused overlay.
 
 ### Hands-Free
 

--- a/index.ts
+++ b/index.ts
@@ -762,17 +762,18 @@ export default function interactiveShellExtension(pi: ExtensionAPI) {
 
 		let effectiveCwd = cwd ?? ctx.cwd;
 		const config = loadRuntimeConfig(effectiveCwd);
-		const isMonitorMode = mode === "monitor";
-		const isNonBlocking = mode === "hands-free" || mode === "dispatch" || isMonitorMode;
+		const effectiveMode = mode ?? "interactive";
+		const isMonitorMode = effectiveMode === "monitor";
+		const returnsImmediately = effectiveMode === "interactive" || effectiveMode === "hands-free" || effectiveMode === "dispatch" || isMonitorMode;
 		const hasUI = ctx.hasUI !== false;
 
-		if (background && mode !== "dispatch" && mode !== "monitor") {
+		if (background && effectiveMode !== "dispatch" && effectiveMode !== "monitor") {
 			return {
 				content: [{ type: "text", text: "background: true requires mode='dispatch' or mode='monitor' for new sessions." }],
 				isError: true,
 			};
 		}
-		if (!isMonitorMode && !(mode === "dispatch" && background)) {
+		if (!isMonitorMode && !(effectiveMode === "dispatch" && background)) {
 			if (!hasUI) {
 				return {
 					content: [{ type: "text", text: "Interactive shell requires interactive TUI mode" }],
@@ -870,7 +871,7 @@ export default function interactiveShellExtension(pi: ExtensionAPI) {
 		}
 		const launchCommand = effectiveCommand;
 
-		if (mode === "dispatch" && background) {
+		if (effectiveMode === "dispatch" && background) {
 			const id = generateSessionId(name);
 			const session = new PtyTerminalSession(
 				{ command: launchCommand, cwd: effectiveCwd, cols: 120, rows: 40, scrollback: config.scrollbackLines },
@@ -894,8 +895,8 @@ export default function interactiveShellExtension(pi: ExtensionAPI) {
 			};
 		}
 
-		const generatedSessionId = isNonBlocking ? generateSessionId(name) : undefined;
-		if (isNonBlocking && generatedSessionId) {
+		const generatedSessionId = returnsImmediately ? generateSessionId(name) : undefined;
+		if (returnsImmediately && generatedSessionId) {
 			if (!coordinator.beginOverlay()) {
 				return {
 					content: [{ type: "text", text: appendWorktreeNotice("An interactive shell overlay is already open. Wait for it to close or kill the active session before starting a new one.", spawnWorktreePath) }],
@@ -914,7 +915,7 @@ export default function interactiveShellExtension(pi: ExtensionAPI) {
 							cwd: effectiveCwd,
 							name,
 							reason: effectiveReason,
-							mode,
+							mode: effectiveMode,
 							sessionId: generatedSessionId,
 							startedAt: overlayStartTime,
 							handsFreeUpdateMode: handsFree?.updateMode,
@@ -922,12 +923,12 @@ export default function interactiveShellExtension(pi: ExtensionAPI) {
 							handsFreeQuietThreshold: handsFree?.quietThreshold,
 							handsFreeUpdateMaxChars: handsFree?.updateMaxChars,
 							handsFreeMaxTotalChars: handsFree?.maxTotalChars,
-							autoExitOnQuiet: mode === "dispatch"
+							autoExitOnQuiet: effectiveMode === "dispatch"
 								? handsFree?.autoExitOnQuiet !== false
-								: handsFree?.autoExitOnQuiet === true,
+								: effectiveMode === "hands-free" && handsFree?.autoExitOnQuiet === true,
 							autoExitGracePeriod: handsFree?.gracePeriod ?? config.autoExitGracePeriod,
 							onUnfocus: () => coordinator.unfocusOverlay(),
-							onHandsFreeUpdate: mode === "hands-free"
+							onHandsFreeUpdate: effectiveMode === "hands-free"
 								? makeNonBlockingUpdateHandler(pi)
 								: undefined,
 							handoffPreviewEnabled: handoffPreview?.enabled,
@@ -947,7 +948,7 @@ export default function interactiveShellExtension(pi: ExtensionAPI) {
 
 			setupDispatchCompletion(pi, overlayPromise, config, {
 				id: generatedSessionId,
-				mode,
+				mode: effectiveMode,
 				command: launchCommand,
 				reason: effectiveReason,
 				timeout,
@@ -955,15 +956,15 @@ export default function interactiveShellExtension(pi: ExtensionAPI) {
 				overlayStartTime,
 			});
 
-			if (mode === "dispatch") {
+			if (effectiveMode === "dispatch") {
 				return {
 					content: [{ type: "text", text: appendWorktreeNotice(`Session dispatched (id: ${generatedSessionId}).\nYou'll be notified when it completes.\nYou can still query with interactive_shell({ sessionId: "${generatedSessionId}" }) if needed.`, spawnWorktreePath) }],
-					details: { sessionId: generatedSessionId, status: "running", command: launchCommand, reason: effectiveReason, mode, spawnAgent, spawnMode, spawnWorktreePath },
+					details: { sessionId: generatedSessionId, status: "running", command: launchCommand, reason: effectiveReason, mode: effectiveMode, spawnAgent, spawnMode, spawnWorktreePath },
 				};
 			}
 			return {
-				content: [{ type: "text", text: appendWorktreeNotice(`Session started: ${generatedSessionId}\nCommand: ${launchCommand}\n\nUse interactive_shell({ sessionId: "${generatedSessionId}" }) to check status/output.\nUse interactive_shell({ sessionId: "${generatedSessionId}", kill: true }) to end when done.`, spawnWorktreePath) }],
-				details: { sessionId: generatedSessionId, status: "running", command: launchCommand, reason: effectiveReason, spawnAgent, spawnMode, spawnWorktreePath },
+				content: [{ type: "text", text: appendWorktreeNotice(`Interactive session started: ${generatedSessionId}\nCommand: ${launchCommand}\n\nUse interactive_shell({ sessionId: "${generatedSessionId}", input: "...", submit: true }) to send input.\nUse interactive_shell({ sessionId: "${generatedSessionId}" }) to check status/output.\nUse interactive_shell({ sessionId: "${generatedSessionId}", kill: true }) to end when done.`, spawnWorktreePath) }],
+				details: { sessionId: generatedSessionId, status: "running", command: launchCommand, reason: effectiveReason, mode: effectiveMode, spawnAgent, spawnMode, spawnWorktreePath },
 			};
 		}
 

--- a/overlay-component.ts
+++ b/overlay-component.ts
@@ -151,6 +151,8 @@ export class InteractiveShellOverlay implements Component, Focusable {
 
 		if (options.mode === "hands-free" || options.mode === "dispatch") {
 			this.state = "hands-free";
+		}
+		if (options.sessionId || this.state === "hands-free") {
 			this.sessionId = options.sessionId ?? generateSessionId(options.name);
 			sessionManager.registerActive({
 				id: this.sessionId,
@@ -167,6 +169,8 @@ export class InteractiveShellOverlay implements Component, Focusable {
 				setQuietThreshold: (thresholdMs) => this.setQuietThreshold(thresholdMs),
 				onComplete: (callback) => this.registerCompleteCallback(callback),
 			});
+		}
+		if (this.state === "hands-free") {
 			this.startHandsFreeUpdates();
 		}
 

--- a/skills/pi-interactive-shell/SKILL.md
+++ b/skills/pi-interactive-shell/SKILL.md
@@ -20,7 +20,7 @@ Pi has two ways to delegate work to other AI coding agents:
 | **User control** | Can take over anytime | Can take over anytime | No intervention |
 | **Best for** | Long tasks needing supervision | Fire-and-forget delegations | Parallel tasks, structured delegation |
 
-**Foreground subagents** run in an overlay where the user watches (and can intervene). Use `interactive_shell` with `mode: "hands-free"` to monitor while receiving periodic updates, or `mode: "dispatch"` to be notified on completion without polling.
+**Foreground subagents** run in an overlay where the user watches and can intervene. Use `interactive_shell` with `mode: "interactive"` when the agent or user will drive the shell by session id, `mode: "hands-free"` to monitor while receiving periodic updates, or `mode: "dispatch"` to be notified on completion without polling.
 
 **Dispatch subagents** also use `interactive_shell` but with `mode: "dispatch"`. The agent fires the session and moves on. When the session completes, the agent is woken up via `triggerTurn` with the output in context. Add `background: true` for headless execution (no overlay).
 
@@ -87,9 +87,10 @@ Quoted prompt text plus `--hands-free` or `--dispatch` turns `/spawn` into a mon
 ## Foreground Subagent Modes
 
 ### Interactive (default)
-User has full control, types directly into the agent.
+The overlay opens and returns a stable `sessionId` immediately. The user can type directly, and the agent can send input to the same shell.
 ```typescript
-interactive_shell({ command: 'pi' })
+const { sessionId } = interactive_shell({ command: 'pi' })
+interactive_shell({ sessionId, input: '/help', submit: true })
 ```
 
 ### Interactive with Initial Prompt

--- a/tests/overlay-render.test.ts
+++ b/tests/overlay-render.test.ts
@@ -67,6 +67,11 @@ function createExistingSession() {
 
 async function loadOverlay() {
 	vi.resetModules();
+	const sessionManager = {
+		registerActive: vi.fn(),
+		unregisterActive: vi.fn(),
+		add: vi.fn(() => "bg-1"),
+	};
 	vi.doMock("@earendil-works/pi-tui", () => ({
 		matchesKey: () => false,
 		truncateToWidth: (value: string, width: number) => value.length > width ? value.slice(0, width) : value,
@@ -76,11 +81,7 @@ async function loadOverlay() {
 		PtyTerminalSession: class MockPtyTerminalSession {},
 	}));
 	vi.doMock("../session-manager.ts", () => ({
-		sessionManager: {
-			registerActive: vi.fn(),
-			unregisterActive: vi.fn(),
-			add: vi.fn(() => "bg-1"),
-		},
+		sessionManager,
 		generateSessionId: vi.fn(() => "session-1"),
 	}));
 	vi.doMock("../handoff-utils.ts", () => ({
@@ -93,7 +94,7 @@ async function loadOverlay() {
 		createSessionQueryState: vi.fn(() => ({})),
 		getSessionOutput: vi.fn(() => ({ output: "", truncated: false, totalBytes: 0 })),
 	}));
-	return import("../overlay-component.ts");
+	return { ...(await import("../overlay-component.ts")), sessionManager };
 }
 
 describe("InteractiveShellOverlay render focus cues", () => {
@@ -103,6 +104,43 @@ describe("InteractiveShellOverlay render focus cues", () => {
 		vi.doUnmock("../session-manager.ts");
 		vi.doUnmock("../handoff-utils.ts");
 		vi.doUnmock("../session-query.ts");
+	});
+
+	it("registers interactive sessions under the supplied control id", async () => {
+		const { InteractiveShellOverlay, sessionManager } = await loadOverlay();
+		const session = createExistingSession();
+		let result: any;
+		const overlay = new InteractiveShellOverlay(
+			{ terminal: { columns: 120, rows: 40 }, requestRender: vi.fn() } as any,
+			{
+				fg: (_color: string, text: string) => text,
+				bg: (_color: string, text: string) => text,
+				bold: (text: string) => text,
+			} as any,
+			{
+				command: "pi",
+				existingSession: session as any,
+				mode: "interactive",
+				sessionId: "control-1",
+			},
+			config,
+			(value) => { result = value; },
+		);
+
+		expect(sessionManager.registerActive).toHaveBeenCalledWith(expect.objectContaining({
+			id: "control-1",
+			command: "pi",
+		}));
+
+		overlay.backgroundSession();
+		expect(sessionManager.add).toHaveBeenCalledWith(
+			"pi",
+			session,
+			undefined,
+			undefined,
+			expect.objectContaining({ id: "control-1" }),
+		);
+		expect(result).toMatchObject({ backgrounded: true, backgroundId: "bg-1", sessionId: "control-1" });
 	});
 
 	it("shows distinct badges and border styles for focused and unfocused states", async () => {

--- a/tests/spawn-command.test.ts
+++ b/tests/spawn-command.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-type OverlayOptionsCapture = { command: string; reason?: string; cwd?: string } | null;
+type OverlayOptionsCapture = { command: string; reason?: string; cwd?: string; mode?: string; sessionId?: string } | null;
 
 type SpawnConfigOverrides = {
 	focusShortcut?: string;
@@ -78,8 +78,8 @@ async function setupExtensionHarness(configOverrides: SpawnConfigOverrides = {})
 	});
 	vi.doMock("../overlay-component.ts", () => ({
 		InteractiveShellOverlay: class MockInteractiveShellOverlay {
-			constructor(_tui: unknown, _theme: unknown, options: { command: string; reason?: string; cwd?: string }) {
-				lastOverlayOptions = { command: options.command, reason: options.reason, cwd: options.cwd };
+			constructor(_tui: unknown, _theme: unknown, options: { command: string; reason?: string; cwd?: string; mode?: string; sessionId?: string }) {
+				lastOverlayOptions = { command: options.command, reason: options.reason, cwd: options.cwd, mode: options.mode, sessionId: options.sessionId };
 			}
 		},
 	}));
@@ -319,8 +319,30 @@ describe("/spawn command, shortcut, and tool spawn", () => {
 		expect(harness.getLastOverlayOptions()).toMatchObject({
 			command: "/opt/codex/bin/codex",
 			reason: "spawn codex (fresh session)",
+			mode: "interactive",
 		});
-		expect(result.content[0].text).toContain("Session ended successfully");
+		expect(harness.getLastOverlayOptions()?.sessionId).toBeTruthy();
+		expect(result.content[0].text).toContain("Interactive session started:");
+		expect(result.content[0].text).toContain("input: \"...\", submit: true");
+		expect(result.details.sessionId).toBe(harness.getLastOverlayOptions()?.sessionId);
+	});
+
+	it("interactive_shell defaults to an agent-controllable interactive session id", async () => {
+		const harness = await setupExtensionHarness();
+		const tool = harness.getTool();
+		expect(tool).toBeTruthy();
+
+		const result = await tool!.execute("call-1", {
+			command: "pi",
+		}, undefined, undefined, harness.ctx as any);
+
+		expect(result.isError).not.toBe(true);
+		expect(result.content[0].text).toContain("Interactive session started:");
+		expect(result.content[0].text).toContain("interactive_shell({ sessionId:");
+		expect(result.content[0].text).toContain("submit: true");
+		expect(result.details.mode).toBe("interactive");
+		expect(result.details.sessionId).toBe(harness.getLastOverlayOptions()?.sessionId);
+		expect(harness.getLastOverlayOptions()).toMatchObject({ command: "pi", mode: "interactive" });
 	});
 
 	it("interactive_shell structured spawn supports native startup prompts", async () => {

--- a/tool-schema.ts
+++ b/tool-schema.ts
@@ -10,8 +10,8 @@ Use this ONLY for delegating tasks to other AI coding agents (Claude Code, Curso
 DO NOT use this for regular bash commands - use the standard bash tool instead.
 
 MODES:
-- interactive (default): User supervises and controls the session
-- hands-free: Agent monitors with periodic updates, user can take over anytime by typing
+- interactive (default): Opens an overlay and immediately returns a stable sessionId for agent/user control
+- hands-free: Opens an overlay, returns a stable sessionId, and sends periodic updates; user can take over anytime by typing
 - dispatch: Agent is notified on completion via triggerTurn (no polling needed)
 - monitor: Run in background and wake the agent on structured monitor events (stream, poll-diff, or file-watch)
 
@@ -28,9 +28,14 @@ The user will see the process in an overlay. They can:
 - Detach (Ctrl+Q) for menu: transfer/background/kill
 - In hands-free mode: type anything to take over control
 
+INTERACTIVE MODE (NON-BLOCKING DEFAULT):
+When mode="interactive" or mode is omitted, the tool returns IMMEDIATELY with a stable sessionId.
+The overlay opens for the user to drive manually, and you can also send input with interactive_shell({ sessionId, input, submit: true }).
+It does not send automatic progress feedback; use the sessionId to query, send input, background, or kill.
+
 HANDS-FREE MODE (NON-BLOCKING):
-When mode="hands-free", the tool returns IMMEDIATELY with a sessionId.
-The overlay opens for the user to watch, but you (the agent) get control back right away.
+When mode="hands-free", the tool returns IMMEDIATELY with a stable sessionId.
+The overlay opens for the user to watch, but you (the agent) get control back right away and receive periodic updates.
 
 Workflow:
 1. Start session: interactive_shell({ command: 'pi "Fix bugs"', mode: "hands-free" })


### PR DESCRIPTION
Fixes #28.

Interactive shell starts now return a stable controllable session id immediately. The agent can send input with `interactive_shell({ sessionId, input, submit: true })` without a reattach dance, while hands-free and dispatch keep their existing feedback behavior.

Validation:
- npm run typecheck
- npx vitest run tests/spawn-command.test.ts tests/overlay-render.test.ts tests/input-submit.test.ts tests/config-and-docs.test.ts --silent
- npm test -- --silent
- fresh review: /tmp/pi-interactive-shell-issue28-review.md