### PR TITLE
docs(tools): broaden interactive_shell description to user-facing CLIs

### DIFF
--- a/tool-schema.ts
+++ b/tool-schema.ts
@@ -5,7 +5,7 @@ export const TOOL_LABEL = "Interactive Shell";
 
 export const TOOL_DESCRIPTION = `Run an interactive CLI coding agent in an overlay.
 
-Use this ONLY for delegating tasks to other AI coding agents (Claude Code, Cursor CLI, Gemini CLI, Codex, etc.) that have their own TUI and benefit from user interaction.
+Use this for delegating tasks to other AI coding agents (Claude Code, Cursor CLI, Gemini CLI, Codex, etc.) that have their own TUI and benefit from user interaction, or for any user-facing CLI that needs the user to type or approve mid-run (e.g. \`npm login\`, credential prompts, interactive wizards).
 
 DO NOT use this for regular bash commands - use the standard bash tool instead.
 


### PR DESCRIPTION
Broadens the `TOOL_DESCRIPTION` in `tool-schema.ts` so the tool isn't framed as *only* for AI coding agents. It now also covers user-facing CLIs that need the user to type or approve mid-run (e.g. `npm login`, credential prompts) — a case where agents previously didn't recognize `interactive_shell` as the right tool.

Verified: `npm run typecheck` and `npm test` (88 tests) pass.

Closes #32 