### PR TITLE
docs: broaden interactive shell CLI guidance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to the `pi-interactive-shell` extension will be documented i
 
 ## [Unreleased]
 
+### Changed
+- Broadened the `interactive_shell` tool guidance to cover user-facing CLIs that need typed input or approval (#32, by @Rianico).
+
 ## [0.14.1] - 2026-08-09
 
 ### Fixed

--- a/index.ts
+++ b/index.ts
@@ -1106,7 +1106,7 @@ export default function interactiveShellExtension(pi: ExtensionAPI) {
 		label: TOOL_LABEL,
 		description: TOOL_DESCRIPTION,
 		promptSnippet:
-			"Use this only to delegate tasks to interactive CLI coding agents (pi/claude/cursor/gemini/codex/aider). Prefer mode='dispatch' for fire-and-forget delegations. When sending slash commands or prompts to an existing session, use submit=true so the text is actually submitted.",
+			"Use this for interactive CLIs that need user input or approval, including coding agents (pi/claude/cursor/gemini/codex/aider) and auth flows such as npm login. Prefer mode='dispatch' for fire-and-forget delegations. Use bash for non-interactive shell commands. When sending slash commands or prompts to an existing session, use submit=true so the text is actually submitted.",
 		parameters: toolParameters,
 
 		async execute(_toolCallId, params, _signal, onUpdate, ctx) {

--- a/tool-schema.ts
+++ b/tool-schema.ts
@@ -3,7 +3,7 @@ import { Type, type Static } from "typebox";
 export const TOOL_NAME = "interactive_shell";
 export const TOOL_LABEL = "Interactive Shell";
 
-export const TOOL_DESCRIPTION = `Run an interactive CLI coding agent in an overlay.
+export const TOOL_DESCRIPTION = `Run an interactive CLI in an overlay.
 
 Use this for delegating tasks to other AI coding agents (Claude Code, Cursor CLI, Gemini CLI, Codex, etc.) that have their own TUI and benefit from user interaction, or for any user-facing CLI that needs the user to type or approve mid-run (e.g. \`npm login\`, credential prompts, interactive wizards).
 

--- a/tool-schema.ts
+++ b/tool-schema.ts
@@ -5,7 +5,7 @@ export const TOOL_LABEL = "Interactive Shell";
 
 export const TOOL_DESCRIPTION = `Run an interactive CLI coding agent in an overlay.
 
-Use this ONLY for delegating tasks to other AI coding agents (Claude Code, Cursor CLI, Gemini CLI, Codex, etc.) that have their own TUI and benefit from user interaction.
+Use this for delegating tasks to other AI coding agents (Claude Code, Cursor CLI, Gemini CLI, Codex, etc.) that have their own TUI and benefit from user interaction, or for any user-facing CLI that needs the user to type or approve mid-run (e.g. \`npm login\`, credential prompts, interactive wizards).
 
 DO NOT use this for regular bash commands - use the standard bash tool instead.
 


### PR DESCRIPTION
## Summary

This replaces #33 with the same accepted wording change plus the follow-up prompt-snippet fix from review.

It broadens `interactive_shell` guidance so agents can use it for interactive coding-agent CLIs and user-facing CLI flows that need typed input or approval, such as `npm login`, while still sending non-interactive shell commands to `bash`.

Credit: based on issue #32 and PR #33 by @Rianico.

Closes #32.
Supersedes #33.

## Validation

- `npm run typecheck`
- `git diff --check origin/main...HEAD`
- Fresh follow-up review on `a91c3ff0c9810f76d15dd58b9717bde4c2c8b161`: No issues found