### PR TITLE
feat: add deferred interactive shell loading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to the `pi-interactive-shell` extension will be documented i
 
 ### Changed
 - Broadened the `interactive_shell` tool guidance to cover user-facing CLIs that need typed input or approval (#32, by @Rianico).
+- Keep `interactive_shell` active when deferred loading cannot expose `enable_interactive_shell` through Pi's tool allowlist (#30, by @AndriiSemenkov).
 
 ## [0.14.1] - 2026-08-09
 

--- a/README.md
+++ b/README.md
@@ -394,16 +394,33 @@ Quoted prompt text plus `--hands-free` or `--dispatch` turns `/spawn` into a mon
 | Alt+Shift+P (default) | Launch the configured default spawn agent (`spawn.shortcut`) |
 | Any key (hands-free) | Take over control |
 
+## Deferred tool loading
+
+`interactive_shell` is active by default. Set `"defer": true` to keep its large tool definition out of the initial model request:
+
+```json
+{
+  "defer": true
+}
+```
+
+Pi then exposes the small `enable_interactive_shell` loader. When a task needs the shell, the agent calls the loader and `interactive_shell` becomes available on the next model turn. `/spawn`, `/attach`, `/dismiss`, and the keyboard shortcuts continue to work directly.
+
+Each reloaded, new, resumed, or forked session starts with `interactive_shell` inactive again. Pi versions without the active-tool API print a warning and keep the tool active. A CLI `--tools` allowlist must include both `enable_interactive_shell` and `interactive_shell`; deferred activation cannot override an allowlist that excludes the target tool.
+
+Deferred mode omits `interactive_shell`'s `promptSnippet`; the same operating guidance remains in the tool description. This keeps the system-prompt prefix stable when Pi uses native deferred loading.
+
 ## Config
 
 Configuration files (project overrides global):
 - **Global:** `~/.pi/agent/interactive-shell.json`
 - **Project:** `.pi/interactive-shell.json`
 
-Shortcut settings are pinned at startup. If you change `focusShortcut` or `spawn.shortcut`, reload or restart Pi to apply them.
+Deferred loading and shortcut settings are pinned at startup. If you change `defer`, `focusShortcut`, or `spawn.shortcut`, reload or restart Pi to apply them.
 
 ```json
 {
+  "defer": false,
   "overlayWidthPercent": 95,
   "overlayHeightPercent": 60,
   "overlayAnchor": "center",
@@ -451,6 +468,7 @@ Shortcut settings are pinned at startup. If you change `focusShortcut` or `spawn
 
 | Setting | Default | Description |
 |---------|---------|-------------|
+| `defer` | `false` | Start each session with only `enable_interactive_shell`; the full tool loads on demand |
 | `overlayWidthPercent` | 95 | Overlay width (10-100%) |
 | `overlayHeightPercent` | 60 | Overlay height (20-90%) |
 | `overlayAnchor` | "center" | Overlay position: `center`, `top-left`, `top-center`, `top-right`, `left-center`, `right-center`, `bottom-left`, `bottom-center`, `bottom-right` |

--- a/config.ts
+++ b/config.ts
@@ -16,6 +16,7 @@ export interface SpawnConfig {
 }
 
 export interface InteractiveShellConfig {
+	defer: boolean;
 	exitAutoCloseDelay: number;
 	overlayWidthPercent: number;
 	overlayHeightPercent: number;
@@ -62,6 +63,7 @@ const DEFAULT_SPAWN_CONFIG: SpawnConfig = {
 };
 
 const DEFAULT_CONFIG: InteractiveShellConfig = {
+	defer: false,
 	exitAutoCloseDelay: 10,
 	overlayWidthPercent: 95,
 	overlayHeightPercent: 60,
@@ -101,6 +103,7 @@ export function loadConfig(cwd: string): InteractiveShellConfig {
 
 	return {
 		...merged,
+		defer: merged.defer === true,
 		exitAutoCloseDelay: clampInt(merged.exitAutoCloseDelay, DEFAULT_CONFIG.exitAutoCloseDelay, 0, 60),
 		overlayWidthPercent: clampPercent(merged.overlayWidthPercent, DEFAULT_CONFIG.overlayWidthPercent),
 		overlayHeightPercent: clampInt(merged.overlayHeightPercent, DEFAULT_CONFIG.overlayHeightPercent, 20, 90),

--- a/index.ts
+++ b/index.ts
@@ -20,7 +20,17 @@ import { loadConfig } from "./config.ts";
 import type { InteractiveShellConfig } from "./config.ts";
 import { isEmptySpawnPlaceholder, normalizeSpawnRequest, parseSpawnArgs, resolveSpawn, type SpawnRequest } from "./spawn.ts";
 import { translateInput, type InputSpec } from "./key-encoding.ts";
-import { TOOL_NAME, TOOL_LABEL, TOOL_DESCRIPTION, toolParameters, type ToolParams } from "./tool-schema.ts";
+import {
+	ENABLE_TOOL_DESCRIPTION,
+	ENABLE_TOOL_LABEL,
+	ENABLE_TOOL_NAME,
+	enableToolParameters,
+	TOOL_NAME,
+	TOOL_LABEL,
+	TOOL_DESCRIPTION,
+	toolParameters,
+	type ToolParams,
+} from "./tool-schema.ts";
 import { HeadlessDispatchMonitor } from "./headless-monitor.ts";
 import type {
 	HeadlessCompletionInfo,
@@ -667,6 +677,11 @@ function appendWorktreeNotice(text: string, worktreePath: string | undefined): s
 
 export default function interactiveShellExtension(pi: ExtensionAPI) {
 	const startupConfig = loadConfig(process.cwd());
+	const supportsDeferredTools = typeof pi.getActiveTools === "function" && typeof pi.setActiveTools === "function";
+	const deferToolLoading = startupConfig.defer && supportsDeferredTools;
+	if (startupConfig.defer && !supportsDeferredTools) {
+		console.error("pi-interactive-shell: deferred loading requires Pi's active-tool APIs; keeping interactive_shell active");
+	}
 	let terminalInputCleanup: (() => void) | null = null;
 	const loadRuntimeConfig = (cwd: string): InteractiveShellConfig => {
 		const config = loadConfig(cwd);
@@ -1070,6 +1085,10 @@ export default function interactiveShellExtension(pi: ExtensionAPI) {
 	});
 
 	pi.on("session_start", (_event, ctx) => {
+		if (deferToolLoading) {
+			const activeTools = pi.getActiveTools().filter((name) => name !== TOOL_NAME);
+			pi.setActiveTools([...new Set([...activeTools, ENABLE_TOOL_NAME])]);
+		}
 		coordinator.replaceBackgroundWidgetCleanup(setupBackgroundWidget(ctx, sessionManager, coordinator));
 		terminalInputCleanup?.();
 		terminalInputCleanup = ctx.ui.onTerminalInput((data) => {
@@ -1105,8 +1124,12 @@ export default function interactiveShellExtension(pi: ExtensionAPI) {
 		name: TOOL_NAME,
 		label: TOOL_LABEL,
 		description: TOOL_DESCRIPTION,
-		promptSnippet:
-			"Use this for interactive CLIs that need user input or approval, including coding agents (pi/claude/cursor/gemini/codex/aider) and auth flows such as npm login. Prefer mode='dispatch' for fire-and-forget delegations. Use bash for non-interactive shell commands. When sending slash commands or prompts to an existing session, use submit=true so the text is actually submitted.",
+		...(deferToolLoading
+			? {}
+			: {
+				promptSnippet:
+					"Use this for interactive CLIs that need user input or approval, including coding agents (pi/claude/cursor/gemini/codex/aider) and auth flows such as npm login. Prefer mode='dispatch' for fire-and-forget delegations. Use bash for non-interactive shell commands. When sending slash commands or prompts to an existing session, use submit=true so the text is actually submitted.",
+			}),
 		parameters: toolParameters,
 
 		async execute(_toolCallId, params, _signal, onUpdate, ctx) {
@@ -1115,6 +1138,36 @@ export default function interactiveShellExtension(pi: ExtensionAPI) {
 			return { content: result.content, details: result.details ?? {}, isError: result.isError };
 		},
 	});
+
+	if (deferToolLoading) {
+		pi.registerTool({
+			name: ENABLE_TOOL_NAME,
+			label: ENABLE_TOOL_LABEL,
+			description: ENABLE_TOOL_DESCRIPTION,
+			promptSnippet: "Enable interactive_shell when an interactive coding-agent CLI, supervised overlay, background dispatch, or event monitor is needed",
+			parameters: enableToolParameters,
+
+			async execute() {
+				const activeTools = pi.getActiveTools();
+				if (activeTools.includes(TOOL_NAME)) {
+					return {
+						content: [{ type: "text" as const, text: "interactive_shell is already available." }],
+						details: { added: [] },
+					};
+				}
+				pi.setActiveTools([...new Set([...activeTools, TOOL_NAME])]);
+				if (!pi.getActiveTools().includes(TOOL_NAME)) {
+					throw new Error(
+						"interactive_shell could not be activated. If Pi was started with --tools, include both enable_interactive_shell and interactive_shell.",
+					);
+				}
+				return {
+					content: [{ type: "text" as const, text: "interactive_shell is now available on the next turn." }],
+					details: { added: [TOOL_NAME] },
+				};
+			},
+		});
+	}
 
 	async function runTool(
 		params: ToolParams,

--- a/index.ts
+++ b/index.ts
@@ -1088,6 +1088,12 @@ export default function interactiveShellExtension(pi: ExtensionAPI) {
 		if (deferToolLoading) {
 			const activeTools = pi.getActiveTools().filter((name) => name !== TOOL_NAME);
 			pi.setActiveTools([...new Set([...activeTools, ENABLE_TOOL_NAME])]);
+			if (!pi.getActiveTools().includes(ENABLE_TOOL_NAME)) {
+				console.error(
+					"pi-interactive-shell: deferred loading requires enable_interactive_shell; include both enable_interactive_shell and interactive_shell in Pi's --tools allowlist. Keeping interactive_shell active.",
+				);
+				pi.setActiveTools([...new Set([...activeTools, TOOL_NAME])]);
+			}
 		}
 		coordinator.replaceBackgroundWidgetCleanup(setupBackgroundWidget(ctx, sessionManager, coordinator));
 		terminalInputCleanup?.();

--- a/skills/pi-interactive-shell/SKILL.md
+++ b/skills/pi-interactive-shell/SKILL.md
@@ -1,11 +1,17 @@
 ---
 name: pi-interactive-shell
-description: Cheat sheet + workflow for launching interactive coding-agent CLIs (Claude Code, Gemini CLI, Codex CLI, Cursor CLI, and pi itself) via the interactive_shell overlay, headless dispatch, or monitor mode. Use for TUI agents and long-running processes that need supervision, fire-and-forget delegation, or event-driven background monitoring. Regular bash commands should use the bash tool instead.
+description: Cheat sheet + workflow for launching interactive coding-agent CLIs (Claude Code, Gemini CLI, Codex CLI, Cursor CLI, and pi itself) via the interactive_shell overlay, headless dispatch, or monitor mode. Use for TUI agents and long-running processes that need supervision, fire-and-forget delegation, or event-driven background monitoring. If interactive_shell is unavailable, enable it with enable_interactive_shell first. Regular bash commands should use the bash tool instead.
 ---
 
 # Interactive Shell (Skill)
 
-Last verified: 2026-04-11
+Last verified: 2026-08-12
+
+## Deferred activation
+
+When `interactive_shell` is unavailable, call `enable_interactive_shell` first. The tool becomes callable on the next turn and stays active until Pi reloads or the session changes; reloaded, new, resumed, and forked sessions reset it to inactive. Do not call the loader when `interactive_shell` is already available.
+
+Users opt in with `"defer": true` in `interactive-shell.json`. Older Pi versions without active-tool APIs warn and keep eager loading. A CLI `--tools` allowlist must include both `enable_interactive_shell` and `interactive_shell`.
 
 ## Foreground vs Background Subagents
 

--- a/tests/config-and-docs.test.ts
+++ b/tests/config-and-docs.test.ts
@@ -84,12 +84,13 @@ describe("config + docs parity", () => {
 		mkdirSync(agentDir, { recursive: true });
 		mkdirSync(join(project, ".pi"), { recursive: true });
 		writeFileSync(globalPath, "[]", { encoding: "utf-8" });
-		writeFileSync(projectPath, '{ "overlayWidthPercent": 1e999, "scrollbackLines": -1e999 }', { encoding: "utf-8" });
+		writeFileSync(projectPath, '{ "defer": true, "overlayWidthPercent": 1e999, "scrollbackLines": -1e999 }', { encoding: "utf-8" });
 		const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
 		try {
 			const { loadConfig } = await loadConfigModule(agentDir);
 			const config = loadConfig(project);
 
+			expect(config.defer).toBe(true);
 			expect(config.overlayWidthPercent).toBe(95);
 			expect(config.scrollbackLines).toBe(5000);
 			expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining(`Ignoring ${globalPath}: config root must be an object`));
@@ -107,9 +108,12 @@ describe("config + docs parity", () => {
 		const skill = readFileSync("skills/pi-interactive-shell/SKILL.md", "utf-8");
 		const toolSchema = readFileSync("tool-schema.ts", "utf-8");
 
+		expect(defaults.defer).toBe(false);
 		expect(defaults.handsFreeQuietThreshold).toBe(8000);
 		expect(defaults.autoExitGracePeriod).toBe(15000);
 		expect(defaults.overlayAnchor).toBe("center");
+		expect(readme).toContain(`"defer": ${defaults.defer}`);
+		expect(readme).toContain("enable_interactive_shell");
 		expect(readme).toContain(`"overlayAnchor": "${defaults.overlayAnchor}"`);
 		expect(defaults.focusShortcut).toBe("alt+shift+f");
 		expect(defaults.spawn.defaultAgent).toBe("pi");
@@ -135,6 +139,8 @@ describe("config + docs parity", () => {
 		expect(readme).toContain(`"autoExitGracePeriod": ${defaults.autoExitGracePeriod}`);
 		expect(readme).toContain(`Dispatch defaults \`autoExitOnQuiet: true\` — the session gets a 15s startup grace period`);
 		expect(readme).toContain("The completion notification identifies this as a quiet auto-close, not a user kill.");
+		expect(skill).toContain("enable_interactive_shell");
+		expect(skill).toContain("reloaded, new, resumed, and forked sessions reset it to inactive");
 		expect(skill).toContain("reports that completion reason separately from a user kill");
 		expect(toolSchema).toContain("reports that completion reason separately from a user kill");
 		expect(readme).toContain('submit: true');

--- a/tests/deferred-loading.test.ts
+++ b/tests/deferred-loading.test.ts
@@ -1,0 +1,181 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const baseConfig = {
+	defer: false,
+	exitAutoCloseDelay: 10,
+	overlayWidthPercent: 95,
+	overlayHeightPercent: 60,
+	overlayAnchor: "center",
+	focusShortcut: "alt+shift+f",
+	spawn: {
+		defaultAgent: "pi",
+		shortcut: "alt+shift+p",
+		commands: { pi: "pi" },
+		defaultArgs: { pi: [] },
+		worktree: false,
+	},
+	scrollbackLines: 5000,
+	ansiReemit: true,
+	handoffPreviewEnabled: true,
+	handoffPreviewLines: 30,
+	handoffPreviewMaxChars: 2000,
+	handoffSnapshotEnabled: false,
+	handoffSnapshotLines: 200,
+	handoffSnapshotMaxChars: 12000,
+	transferLines: 200,
+	transferMaxChars: 20000,
+	completionNotifyLines: 50,
+	completionNotifyMaxChars: 5000,
+	handsFreeUpdateMode: "on-quiet",
+	handsFreeUpdateInterval: 60000,
+	handsFreeQuietThreshold: 8000,
+	autoExitGracePeriod: 15000,
+	handsFreeUpdateMaxChars: 1500,
+	handsFreeMaxTotalChars: 100000,
+	minQueryIntervalSeconds: 60,
+};
+
+async function setupHarness(defer: boolean, dynamicApis = true, allowInteractiveShell = true) {
+	vi.resetModules();
+	vi.doMock("@earendil-works/pi-coding-agent", () => ({
+		getAgentDir: () => "/tmp/pi-agent",
+	}));
+	vi.doMock("@earendil-works/pi-tui", () => ({
+		isKeyRelease: () => false,
+		isKeyRepeat: () => false,
+		matchesKey: () => false,
+		truncateToWidth: (value: string) => value,
+		visibleWidth: (value: string) => value.length,
+	}));
+	vi.doMock("../config.ts", () => ({
+		loadConfig: () => ({ ...baseConfig, defer }),
+	}));
+	vi.doMock("../overlay-component.ts", () => ({ InteractiveShellOverlay: class {} }));
+	vi.doMock("../reattach-overlay.ts", () => ({ ReattachOverlay: class {} }));
+	vi.doMock("../pty-session.ts", () => ({ PtyTerminalSession: class {} }));
+	vi.doMock("../headless-monitor.ts", () => ({ HeadlessDispatchMonitor: class {} }));
+	vi.doMock("../background-widget.ts", () => ({ setupBackgroundWidget: () => () => {} }));
+	vi.doMock("../session-manager.ts", () => ({
+		sessionManager: {
+			killAll: vi.fn(),
+			onChange: vi.fn(() => () => {}),
+			list: vi.fn(() => []),
+		},
+		generateSessionId: () => "test-session",
+	}));
+
+	const { default: extension } = await import("../index.ts");
+	const tools = new Map<string, any>();
+	const handlers = new Map<string, any>();
+	let activeTools = ["read"];
+	const setActiveTools = vi.fn((names: string[]) => {
+		activeTools = allowInteractiveShell ? [...names] : names.filter((name) => name !== "interactive_shell");
+	});
+	const pi: Record<string, any> = {
+		registerShortcut: vi.fn(),
+		registerCommand: vi.fn(),
+		registerTool: vi.fn((tool: any) => {
+			tools.set(tool.name, tool);
+			activeTools.push(tool.name);
+		}),
+		on: vi.fn((event: string, handler: any) => handlers.set(event, handler)),
+		events: { emit: vi.fn() },
+		sendMessage: vi.fn(),
+	};
+	if (dynamicApis) {
+		pi.getActiveTools = vi.fn(() => [...activeTools]);
+		pi.setActiveTools = setActiveTools;
+	}
+
+	extension(pi as any);
+	return { pi, tools, handlers, getActiveTools: () => activeTools, setActiveTools };
+}
+
+const sessionContext = {
+	ui: {
+		notify: vi.fn(),
+		onTerminalInput: vi.fn(() => () => {}),
+	},
+};
+
+describe("deferred interactive_shell loading", () => {
+	afterEach(() => {
+		vi.restoreAllMocks();
+		vi.doUnmock("@earendil-works/pi-coding-agent");
+		vi.doUnmock("@earendil-works/pi-tui");
+		vi.doUnmock("../config.ts");
+		vi.doUnmock("../overlay-component.ts");
+		vi.doUnmock("../reattach-overlay.ts");
+		vi.doUnmock("../pty-session.ts");
+		vi.doUnmock("../headless-monitor.ts");
+		vi.doUnmock("../background-widget.ts");
+		vi.doUnmock("../session-manager.ts");
+	});
+
+	it("keeps the current eager tool contract by default", async () => {
+		const harness = await setupHarness(false);
+
+		expect([...harness.tools.keys()]).toEqual(["interactive_shell"]);
+		expect(harness.tools.get("interactive_shell").promptSnippet).toContain("submit=true");
+		expect(harness.setActiveTools).not.toHaveBeenCalled();
+	});
+
+	it("starts deferred sessions with only the loader and re-enables the tool additively", async () => {
+		const harness = await setupHarness(true);
+		const sessionStart = harness.handlers.get("session_start");
+
+		expect([...harness.tools.keys()]).toEqual(["interactive_shell", "enable_interactive_shell"]);
+		expect(harness.tools.get("interactive_shell").promptSnippet).toBeUndefined();
+		expect(harness.pi.registerCommand).toHaveBeenCalledWith("spawn", expect.anything());
+		expect(harness.pi.registerCommand).toHaveBeenCalledWith("attach", expect.anything());
+		expect(harness.pi.registerCommand).toHaveBeenCalledWith("dismiss", expect.anything());
+		expect(harness.pi.registerShortcut).toHaveBeenCalledTimes(2);
+
+		sessionStart({ reason: "startup" }, sessionContext);
+		expect(harness.getActiveTools()).toEqual(["read", "enable_interactive_shell"]);
+
+		const loader = harness.tools.get("enable_interactive_shell");
+		const result = await loader.execute("load-1", {}, undefined, undefined, sessionContext);
+		expect(harness.getActiveTools()).toEqual(["read", "enable_interactive_shell", "interactive_shell"]);
+		expect(result.content[0].text).toContain("next turn");
+		expect(result.details.added).toEqual(["interactive_shell"]);
+
+		const callsAfterActivation = harness.setActiveTools.mock.calls.length;
+		const repeated = await loader.execute("load-2", {}, undefined, undefined, sessionContext);
+		expect(harness.setActiveTools).toHaveBeenCalledTimes(callsAfterActivation);
+		expect(repeated.details.added).toEqual([]);
+	});
+
+	it("fails clearly when a CLI tool allowlist excludes interactive_shell", async () => {
+		const harness = await setupHarness(true, true, false);
+		const sessionStart = harness.handlers.get("session_start");
+		const loader = harness.tools.get("enable_interactive_shell");
+
+		sessionStart({ reason: "startup" }, sessionContext);
+		await expect(loader.execute("load-1", {}, undefined, undefined, sessionContext)).rejects.toThrow(
+			"include both enable_interactive_shell and interactive_shell",
+		);
+	});
+
+	it("resets the interactive tool to inactive on every session start", async () => {
+		const harness = await setupHarness(true);
+		const sessionStart = harness.handlers.get("session_start");
+		const loader = harness.tools.get("enable_interactive_shell");
+
+		sessionStart({ reason: "startup" }, sessionContext);
+		await loader.execute("load-1", {}, undefined, undefined, sessionContext);
+		expect(harness.getActiveTools()).toContain("interactive_shell");
+
+		sessionStart({ reason: "fork" }, sessionContext);
+		expect(harness.getActiveTools()).toEqual(["read", "enable_interactive_shell"]);
+	});
+
+	it("warns and stays eager when the active-tool APIs are unavailable", async () => {
+		const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+		const harness = await setupHarness(true, false);
+
+		expect([...harness.tools.keys()]).toEqual(["interactive_shell"]);
+		expect(harness.tools.get("interactive_shell").promptSnippet).toContain("submit=true");
+		expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining("deferred loading requires"));
+	});
+});

--- a/tests/deferred-loading.test.ts
+++ b/tests/deferred-loading.test.ts
@@ -35,7 +35,7 @@ const baseConfig = {
 	minQueryIntervalSeconds: 60,
 };
 
-async function setupHarness(defer: boolean, dynamicApis = true, allowInteractiveShell = true) {
+async function setupHarness(defer: boolean, dynamicApis = true, allowedTools = ["interactive_shell", "enable_interactive_shell"]) {
 	vi.resetModules();
 	vi.doMock("@earendil-works/pi-coding-agent", () => ({
 		getAgentDir: () => "/tmp/pi-agent",
@@ -69,7 +69,7 @@ async function setupHarness(defer: boolean, dynamicApis = true, allowInteractive
 	const handlers = new Map<string, any>();
 	let activeTools = ["read"];
 	const setActiveTools = vi.fn((names: string[]) => {
-		activeTools = allowInteractiveShell ? [...names] : names.filter((name) => name !== "interactive_shell");
+		activeTools = names.filter((name) => !["interactive_shell", "enable_interactive_shell"].includes(name) || allowedTools.includes(name));
 	});
 	const pi: Record<string, any> = {
 		registerShortcut: vi.fn(),
@@ -146,8 +146,18 @@ describe("deferred interactive_shell loading", () => {
 		expect(repeated.details.added).toEqual([]);
 	});
 
+	it("keeps interactive_shell active when a CLI tool allowlist excludes the loader", async () => {
+		const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+		const harness = await setupHarness(true, true, ["interactive_shell"]);
+		const sessionStart = harness.handlers.get("session_start");
+
+		sessionStart({ reason: "startup" }, sessionContext);
+		expect(harness.getActiveTools()).toEqual(["read", "interactive_shell"]);
+		expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining("include both enable_interactive_shell and interactive_shell"));
+	});
+
 	it("fails clearly when a CLI tool allowlist excludes interactive_shell", async () => {
-		const harness = await setupHarness(true, true, false);
+		const harness = await setupHarness(true, true, ["enable_interactive_shell"]);
 		const sessionStart = harness.handlers.get("session_start");
 		const loader = harness.tools.get("enable_interactive_shell");
 

--- a/tests/headless-monitor.test.ts
+++ b/tests/headless-monitor.test.ts
@@ -3,6 +3,7 @@ import { HeadlessDispatchMonitor } from "../headless-monitor.ts";
 import type { InteractiveShellConfig } from "../config.ts";
 
 const config: InteractiveShellConfig = {
+	defer: false,
 	exitAutoCloseDelay: 10,
 	overlayWidthPercent: 95,
 	overlayHeightPercent: 60,

--- a/tests/overlay-render.test.ts
+++ b/tests/overlay-render.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import type { InteractiveShellConfig } from "../config.ts";
 
 const config: InteractiveShellConfig = {
+	defer: false,
 	exitAutoCloseDelay: 10,
 	overlayWidthPercent: 95,
 	overlayHeightPercent: 60,

--- a/tests/session-query.test.ts
+++ b/tests/session-query.test.ts
@@ -3,6 +3,7 @@ import { createSessionQueryState, getSessionOutput } from "../session-query.ts";
 import type { InteractiveShellConfig } from "../config.ts";
 
 const config: InteractiveShellConfig = {
+	defer: false,
 	exitAutoCloseDelay: 10,
 	overlayWidthPercent: 95,
 	overlayHeightPercent: 60,

--- a/tests/spawn.test.ts
+++ b/tests/spawn.test.ts
@@ -3,6 +3,7 @@ import type { InteractiveShellConfig } from "../config.ts";
 import type { SpawnRequest } from "../spawn.ts";
 
 const config: InteractiveShellConfig = {
+	defer: false,
 	exitAutoCloseDelay: 10,
 	overlayWidthPercent: 95,
 	overlayHeightPercent: 60,

--- a/tool-schema.ts
+++ b/tool-schema.ts
@@ -2,6 +2,10 @@ import { Type, type Static } from "typebox";
 
 export const TOOL_NAME = "interactive_shell";
 export const TOOL_LABEL = "Interactive Shell";
+export const ENABLE_TOOL_NAME = "enable_interactive_shell";
+export const ENABLE_TOOL_LABEL = "Enable Interactive Shell";
+export const ENABLE_TOOL_DESCRIPTION = "Enable the interactive_shell tool for interactive CLI coding agents, overlay supervision, background dispatch, and event-driven monitoring. Call this when interactive_shell is not available; it becomes callable on the next turn.";
+export const enableToolParameters = Type.Object({});
 
 export const TOOL_DESCRIPTION = `Run an interactive CLI in an overlay.
 


### PR DESCRIPTION
## Summary

This replaces #31 so the deferred-loading change can land from a maintainer branch after review fixes and the #34 base update.

It adds opt-in `defer: true` support for `interactive_shell`. Deferred mode keeps eager loading as the default, exposes a small `enable_interactive_shell` loader, resets on session starts, preserves old Pi runtime behavior, and handles `--tools` allowlists without stranding users.

Credit: based on issue #30 and PR #31 by @AndriiSemenkov.

Closes #30.
Supersedes #31.

## Validation

- `npm run typecheck`
- `npm test -- tests/deferred-loading.test.ts tests/config-and-docs.test.ts`
- `git diff --check origin/main...HEAD`
- Fresh exact-head review on `00cc85220fce97017fe7e6aa11aa4aa087db6027`: No issues found