### PR TITLE
refactor: polish spawn result optional fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to the `pi-interactive-shell` extension will be documented i
 ### Changed
 - Broadened the `interactive_shell` tool guidance to cover user-facing CLIs that need typed input or approval (#32, by @Rianico).
 - Keep `interactive_shell` active when deferred loading cannot expose `enable_interactive_shell` through Pi's tool allowlist (#30, by @AndriiSemenkov).
+- Omit absent optional spawn fields from parsed and resolved spawn results.
 
 ## [0.14.1] - 2026-08-09
 

--- a/index.ts
+++ b/index.ts
@@ -1,4 +1,4 @@
-import type { AgentToolResult, ExtensionAPI, ExtensionContext, ExtensionUIContext } from "@earendil-works/pi-coding-agent";
+import type { ExtensionAPI, ExtensionContext, ExtensionUIContext } from "@earendil-works/pi-coding-agent";
 import { isKeyRelease, isKeyRepeat, matchesKey } from "@earendil-works/pi-tui";
 import { InteractiveShellOverlay } from "./overlay-component.ts";
 import { ReattachOverlay } from "./reattach-overlay.ts";

--- a/overlay-component.ts
+++ b/overlay-component.ts
@@ -7,7 +7,6 @@ import { sessionManager, generateSessionId } from "./session-manager.ts";
 import type { InteractiveShellConfig } from "./config.ts";
 import {
 	type InteractiveShellResult,
-	type HandsFreeUpdate,
 	type InteractiveShellOptions,
 	type DialogChoice,
 	type OverlayState,

--- a/spawn.ts
+++ b/spawn.ts
@@ -135,13 +135,16 @@ export function parseSpawnArgs(args: string, agents: readonly SpawnAgent[]):
 		};
 	}
 
-	return {
-		ok: true,
-		parsed: {
-			request: { agent, mode, worktree: worktree || undefined, prompt },
-			monitorMode,
-		},
-	};
+	const request: SpawnRequest = {};
+	if (agent !== undefined) request.agent = agent;
+	if (mode !== undefined) request.mode = mode;
+	if (worktree) request.worktree = true;
+	if (prompt !== undefined) request.prompt = prompt;
+
+	const parsed: ParsedSpawnArgs = { request };
+	if (monitorMode !== undefined) parsed.monitorMode = monitorMode;
+
+	return { ok: true, parsed };
 }
 
 export function resolveSpawn(
@@ -204,17 +207,16 @@ export function resolveSpawn(
 		reason += ` • worktree: ${worktreePath}`;
 	}
 
-	return {
-		ok: true,
-		spawn: {
-			agent,
-			mode,
-			command: buildShellCommand(executable, args),
-			cwd: effectiveCwd,
-			reason,
-			worktreePath,
-		},
+	const resolved: ResolvedSpawn = {
+		agent,
+		mode,
+		command: buildShellCommand(executable, args),
+		cwd: effectiveCwd,
+		reason,
 	};
+	if (worktreePath !== undefined) resolved.worktreePath = worktreePath;
+
+	return { ok: true, spawn: resolved };
 }
 
 function createSpawnWorktree(

--- a/tests/spawn.test.ts
+++ b/tests/spawn.test.ts
@@ -1,6 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { InteractiveShellConfig } from "../config.ts";
-import type { SpawnRequest } from "../spawn.ts";
 
 const config: InteractiveShellConfig = {
 	defer: false,
@@ -50,28 +49,27 @@ describe("spawn helpers", () => {
 		expect(parseSpawnArgs('claude "review the diffs" --dispatch', AGENTS)).toEqual({
 			ok: true,
 			parsed: {
-				request: { agent: "claude", mode: undefined, worktree: undefined, prompt: "review the diffs" },
+				request: { agent: "claude", prompt: "review the diffs" },
 				monitorMode: "dispatch",
 			},
 		});
 		expect(parseSpawnArgs("codex fork --worktree", AGENTS)).toEqual({
 			ok: true,
 			parsed: {
-				request: { agent: "codex", mode: "fork", worktree: true, prompt: undefined },
-				monitorMode: undefined,
+				request: { agent: "codex", mode: "fork", worktree: true },
 			},
 		});
 		expect(parseSpawnArgs('cursor "review the diffs" --dispatch', AGENTS)).toEqual({
 			ok: true,
 			parsed: {
-				request: { agent: "cursor", mode: undefined, worktree: undefined, prompt: "review the diffs" },
+				request: { agent: "cursor", prompt: "review the diffs" },
 				monitorMode: "dispatch",
 			},
 		});
 		expect(parseSpawnArgs('"fix the failing tests" --hands-free', AGENTS)).toEqual({
 			ok: true,
 			parsed: {
-				request: { agent: undefined, mode: undefined, worktree: undefined, prompt: "fix the failing tests" },
+				request: { prompt: "fix the failing tests" },
 				monitorMode: "hands-free",
 			},
 		});
@@ -106,8 +104,7 @@ describe("spawn helpers", () => {
 		expect(parseSpawnArgs("aider --worktree", [...AGENTS, "aider"])).toEqual({
 			ok: true,
 			parsed: {
-				request: { agent: "aider", mode: undefined, worktree: true, prompt: undefined },
-				monitorMode: undefined,
+				request: { agent: "aider", worktree: true },
 			},
 		});
 		expect(resolveSpawn({
@@ -125,7 +122,6 @@ describe("spawn helpers", () => {
 				command: "aider --yes-always 'fix the build'",
 				cwd: "/tmp/project",
 				reason: "spawn aider (fresh session)",
-				worktreePath: undefined,
 			},
 		});
 	});
@@ -157,7 +153,6 @@ describe("spawn helpers", () => {
 				command: "codex -c 'model_reasoning_effort=\"high\"'",
 				cwd: "/tmp/project",
 				reason: "spawn codex (fresh session)",
-				worktreePath: undefined,
 			},
 		});
 	});
@@ -172,7 +167,6 @@ describe("spawn helpers", () => {
 				command: "claude 'review the diffs'",
 				cwd: "/tmp/project",
 				reason: "spawn claude (fresh session)",
-				worktreePath: undefined,
 			},
 		});
 		expect(resolveSpawn(config, "/tmp/project", { agent: "cursor", prompt: "review the diffs" }, () => "/tmp/project/session.jsonl")).toEqual({
@@ -183,7 +177,6 @@ describe("spawn helpers", () => {
 				command: "agent --model composer-2-fast 'review the diffs'",
 				cwd: "/tmp/project",
 				reason: "spawn cursor (fresh session)",
-				worktreePath: undefined,
 			},
 		});
 		expect(resolveSpawn(config, "/tmp/project", { agent: "pi", mode: "fork", prompt: "continue from here" }, () => "/tmp/project/session.jsonl")).toEqual({
@@ -194,7 +187,6 @@ describe("spawn helpers", () => {
 				command: "pi --fork /tmp/project/session.jsonl 'continue from here'",
 				cwd: "/tmp/project",
 				reason: "spawn pi (fork current session)",
-				worktreePath: undefined,
 			},
 		});
 	});


### PR DESCRIPTION
## Summary

This is a small TypeScript polish pass for the spawn helpers.

It omits absent optional fields from parsed and resolved spawn results instead of setting them to `undefined`, removes stale type-only imports, and updates the spawn tests to assert the tighter object shape.

## Validation

- `npm run typecheck`
- `npm test`
- `npx tsc -p tsconfig.json --noEmit --noUnusedLocals --noUnusedParameters --pretty false`
- `git diff --check HEAD~1..HEAD`
- `git diff --check`
- Fresh exact-head review on `27d5c961986d686915235ad70caea28fecc71b78`: No issues found