### PR TITLE
docs: align package installation guidance

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Nico Bailon
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Works with any CLI: `vim`, `htop`, `psql`, `ssh`, `docker logs -f`, `npm run dev
 pi install npm:pi-interactive-shell
 ```
 
-The `interactive-shell` skill is automatically symlinked to `~/.pi/agent/skills/interactive-shell/`.
+Pi loads the bundled `pi-interactive-shell` skill directly from the package manifest; no manual copy or symlink is required.
 
 **Requires:** Node.js. PTY support uses `zigpty` prebuilt binaries (no `node-gyp` toolchain required on supported platforms).
 
@@ -537,16 +537,18 @@ pi install npm:pi-interactive-shell
 The Codex workflow prompts and supporting skills are opt-in examples. Copy them into your agent config if you want to use them:
 
 ```bash
+PACKAGE_DIR="$HOME/.pi/agent/npm/node_modules/pi-interactive-shell"
+
 # Prompt templates (slash commands)
-cp ~/.pi/agent/extensions/pi-interactive-shell/examples/prompts/*.md ~/.pi/agent/prompts/
+cp "$PACKAGE_DIR"/examples/prompts/*.md ~/.pi/agent/prompts/
 
 # Optional skills used by the templates
-cp -r ~/.pi/agent/extensions/pi-interactive-shell/examples/skills/codex-cli ~/.pi/agent/skills/
-cp -r ~/.pi/agent/extensions/pi-interactive-shell/examples/skills/gpt-5-4-prompting ~/.pi/agent/skills/
-cp -r ~/.pi/agent/extensions/pi-interactive-shell/examples/skills/codex-5-3-prompting ~/.pi/agent/skills/
+cp -r "$PACKAGE_DIR"/examples/skills/codex-cli ~/.pi/agent/skills/
+cp -r "$PACKAGE_DIR"/examples/skills/gpt-5-4-prompting ~/.pi/agent/skills/
+cp -r "$PACKAGE_DIR"/examples/skills/codex-5-3-prompting ~/.pi/agent/skills/
 
 # Optional CLI reference skill
-cp -r ~/.pi/agent/extensions/pi-interactive-shell/examples/skills/cursor-cli ~/.pi/agent/skills/
+cp -r "$PACKAGE_DIR"/examples/skills/cursor-cli ~/.pi/agent/skills/
 ```
 
 ### Usage


### PR DESCRIPTION
## Summary

- add the MIT license file declared by `package.json`, using the same copyright notice as the author's other 2026 Pi packages
- clarify that Pi loads the bundled skill through the package manifest rather than creating a user-level symlink
- update the opt-in example copy commands to the current npm package location under `~/.pi/agent/npm/node_modules`

## Validation

- `npm run typecheck`
- `npm test` — 94 tests passed
- `npm pack --dry-run --json` — `LICENSE` included in the package
- `git diff --check`
