### PR TITLE
fix: clarify watcher quiet auto-close

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to the `pi-interactive-shell` extension will be documented i
 
 ## [Unreleased]
 
+### Fixed
+- Expose dispatch quiet auto-close as `completionReason: "auto-close-quiet"` and mark it as non-terminal in notifications.
+
+### Changed
+- Document a provider-agnostic watch-until-terminal monitor recipe for external gates.
+
 ## [0.15.0] - 2026-08-13
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -153,7 +153,28 @@ Attach to review full output: interactive_shell({ attach: "calm-reef" })
 
 The notification includes a brief tail (last 5 lines) and a reattach instruction. The PTY is preserved for 5 minutes so the agent can attach to review full scrollback.
 
-Dispatch defaults `autoExitOnQuiet: true` — the session gets a 15s startup grace period, then auto-closes after output goes silent (8s by default). The completion notification identifies this as a quiet auto-close, not a user kill. Tune the grace period with `handsFree: { gracePeriod: 60000 }` or opt out entirely with `handsFree: { autoExitOnQuiet: false }`.
+Dispatch defaults `autoExitOnQuiet: true` — the session gets a 15s startup grace period, then auto-closes after output goes silent (8s by default). The completion notification and details set `completionReason: "auto-close-quiet"`; this is not a terminal command verdict. Tune the grace period with `handsFree: { gracePeriod: 60000 }` or opt out entirely with `handsFree: { autoExitOnQuiet: false }`.
+
+For an external gate, use this provider-agnostic watch-until-terminal pattern. The watcher must print one of the terminal lines and exit only after it has a verdict:
+
+```typescript
+interactive_shell({
+  command: "your-watch-command",
+  mode: "monitor",
+  handsFree: { autoExitOnQuiet: false },
+  timeout: 20 * 60_000,
+  monitor: {
+    strategy: "stream",
+    triggers: [
+      { id: "ready", literal: "ready" },
+      { id: "blocked", literal: "blocked" },
+      { id: "stale-head", literal: "stale-head" }
+    ]
+  }
+})
+```
+
+This works with CI, deploy, health, and custom CLI watchers. If raw dispatch is required, disable quiet auto-close and treat `completionReason: "auto-close-quiet"` as non-terminal.
 
 The overlay still shows for the user, who can Ctrl+T to transfer output, Ctrl+B to background, take over by typing, or Ctrl+Q for more options. `Ctrl+G` only becomes meaningful after the user has taken over a monitored hands-free or dispatch session.
 

--- a/headless-monitor.ts
+++ b/headless-monitor.ts
@@ -1,7 +1,7 @@
 import { stripVTControlCharacters } from "node:util";
 import type { PtyTerminalSession } from "./pty-session.ts";
 import type { InteractiveShellConfig } from "./config.ts";
-import type { MonitorEventPayload, MonitorStrategy } from "./types.ts";
+import type { DispatchCompletionReason, MonitorEventPayload, MonitorStrategy } from "./types.ts";
 
 export interface MonitorMatchInfo {
 	strategy: MonitorStrategy;
@@ -42,6 +42,8 @@ export interface HeadlessMonitorOptions {
 export interface HeadlessCompletionInfo {
 	exitCode: number | null;
 	signal?: number;
+	/** `auto-close-quiet` means the extension stopped a non-terminal quiet command. */
+	completionReason: DispatchCompletionReason;
 	timedOut?: boolean;
 	cancelled?: boolean;
 	/** The monitor ended an otherwise idle session after the configured quiet threshold. */
@@ -267,7 +269,6 @@ export class HeadlessDispatchMonitor {
 					this.resetQuietTimer();
 					return;
 				}
-				this.session.kill();
 				this.handleCompletion(null, undefined, false, true, true);
 			}
 		}, this.options.quietThreshold);
@@ -309,14 +310,22 @@ export class HeadlessDispatchMonitor {
 		if (this.timeoutTimer) { clearTimeout(this.timeoutTimer); this.timeoutTimer = null; }
 		this.unsubscribe();
 
-		if (timedOut) {
+		if (timedOut || cancelled) {
 			this.session.kill();
 		}
 
 		const completionOutput = this.captureOutput();
+		const completionReason: DispatchCompletionReason = autoClosedOnQuiet
+			? "auto-close-quiet"
+			: timedOut
+				? "timed-out"
+				: cancelled
+					? "killed"
+					: "exited";
 		const info: HeadlessCompletionInfo = {
 			exitCode,
 			signal,
+			completionReason,
 			timedOut,
 			cancelled,
 			...(autoClosedOnQuiet ? { autoClosedOnQuiet: true } : {}),
@@ -325,6 +334,10 @@ export class HeadlessDispatchMonitor {
 		this.result = info;
 		this.triggerCompleteCallbacks();
 		this.onComplete(info);
+	}
+
+	kill(): void {
+		this.handleCompletion(null, undefined, false, true);
 	}
 
 	handleExternalCompletion(exitCode: number | null, signal?: number, completionOutput?: HeadlessCompletionInfo["completionOutput"]): void {
@@ -339,7 +352,7 @@ export class HeadlessDispatchMonitor {
 		this.unsubscribe();
 
 		const output = completionOutput ?? this.captureOutput();
-		const info: HeadlessCompletionInfo = { exitCode, signal, completionOutput: output };
+		const info: HeadlessCompletionInfo = { exitCode, signal, completionReason: "exited", completionOutput: output };
 		this.result = info;
 		this.triggerCompleteCallbacks();
 		this.onComplete(info);

--- a/index.ts
+++ b/index.ts
@@ -606,7 +606,7 @@ function registerHeadlessActive(
 			}
 			const liveMonitor = coordinator.getMonitor(id);
 			if (liveMonitor && !liveMonitor.disposed) {
-				session.kill();
+				liveMonitor.kill();
 				return;
 			}
 			coordinator.disposeMonitor(id);
@@ -1979,11 +1979,12 @@ function setupDispatchCompletion(
 					customType: "interactive-shell-transfer",
 					content,
 					display: true,
-					details: { sessionId: id, exitCode: result.exitCode, signal: result.signal, timedOut: result.timedOut, cancelled: result.cancelled, completionOutput: result.completionOutput },
+					details: { sessionId: id, exitCode: result.exitCode, signal: result.signal, completionReason: result.completionReason, timedOut: result.timedOut, cancelled: result.cancelled, completionOutput: result.completionOutput },
 				}, { triggerTurn: true });
 			}
 			pi.events.emit("interactive-shell:transfer", {
 				sessionId: id,
+				completionReason: result.completionReason,
 				completionOutput: result.completionOutput,
 				exitCode: result.exitCode,
 				signal: result.signal,

--- a/notification-utils.ts
+++ b/notification-utils.ts
@@ -137,7 +137,7 @@ export function buildIdlePromptWarning(command: string, reason: string | undefin
 
 function buildDispatchStatusLine(sessionId: string, info: HeadlessCompletionInfo, duration: string): string {
 	if (info.timedOut) return `Session ${sessionId} timed out (${duration}).`;
-	if (info.autoClosedOnQuiet) return `Session ${sessionId} auto-closed after quiet (${duration}).`;
+	if (info.completionReason === "auto-close-quiet") return `Session ${sessionId} auto-closed after quiet (${duration}). This is not a terminal command verdict.`;
 	if (info.cancelled) return `Session ${sessionId} was killed (${duration}).`;
 	if (info.exitCode === 0) return `Session ${sessionId} completed successfully (${duration}).`;
 	return `Session ${sessionId} exited with code ${info.exitCode} (${duration}).`;
@@ -145,6 +145,7 @@ function buildDispatchStatusLine(sessionId: string, info: HeadlessCompletionInfo
 
 function buildResultStatusLine(sessionId: string, result: InteractiveShellResult): string {
 	if (result.timedOut) return `Session ${sessionId} timed out.`;
+	if (result.completionReason === "auto-close-quiet") return `Session ${sessionId} auto-closed after quiet. This is not a terminal command verdict.`;
 	if (result.cancelled) return `Session ${sessionId} was killed.`;
 	if (result.exitCode === 0) return `Session ${sessionId} completed successfully.`;
 	return `Session ${sessionId} exited with code ${result.exitCode}.`;

--- a/overlay-component.ts
+++ b/overlay-component.ts
@@ -352,8 +352,8 @@ export class InteractiveShellOverlay implements Component, Focusable {
 						this.emitHandsFreeUpdate();
 						this.hasUnsentData = false;
 					}
-					// Send completion notification and auto-close
-					// Use "killed" status since we're forcibly terminating (matches finishWithKill's cancelled=true)
+					// Send completion notification and auto-close.
+					// This is a quiet auto-close, not a command completion verdict.
 					if (this.options.onHandsFreeUpdate && this.sessionId) {
 						this.options.onHandsFreeUpdate({
 							status: "killed",
@@ -365,7 +365,7 @@ export class InteractiveShellOverlay implements Component, Focusable {
 							budgetExhausted: this.budgetExhausted,
 						});
 					}
-					this.finishWithKill();
+					this.finishWithKill("auto-close-quiet");
 					return;
 				}
 				// Normal behavior: just emit update
@@ -685,7 +685,7 @@ export class InteractiveShellOverlay implements Component, Focusable {
 		this.done(result);
 	}
 
-	private finishWithKill(): void {
+	private finishWithKill(completionReason: InteractiveShellResult["completionReason"] = "killed"): void {
 		if (this.finished) return;
 		this.finished = true;
 		this.stopCountdown();
@@ -699,6 +699,7 @@ export class InteractiveShellOverlay implements Component, Focusable {
 		this.session.dispose();
 		const result: InteractiveShellResult = {
 			exitCode: null,
+			completionReason,
 			backgrounded: false,
 			cancelled: true,
 			sessionId: this.sessionId ?? undefined,

--- a/skills/pi-interactive-shell/SKILL.md
+++ b/skills/pi-interactive-shell/SKILL.md
@@ -119,7 +119,9 @@ interactive_shell({
 // → Do other work. When session completes, you receive notification with output.
 ```
 
-Dispatch defaults `autoExitOnQuiet: true`. A quiet TUI auto-closes after the threshold and reports that completion reason separately from a user kill. The agent can still query the sessionId if needed, but doesn't have to.
+Dispatch defaults `autoExitOnQuiet: true`. A quiet TUI auto-closes after the threshold and reports `completionReason: "auto-close-quiet"` separately from a user kill. This is not a terminal command verdict. The agent can still query the sessionId if needed, but doesn't have to.
+
+For a provider-agnostic external gate watcher, use `mode: "monitor"`, set `handsFree: { autoExitOnQuiet: false }`, set a hard `timeout`, and match explicit terminal lines such as `ready`, `blocked`, and `stale-head`. The watcher command must exit only after it emits a terminal line. If raw dispatch is required, disable quiet auto-close and treat `completionReason: "auto-close-quiet"` as non-terminal.
 
 For fire-and-forget delegated runs (including QA-style delegated checks), prefer dispatch as the default mode.
 

--- a/tests/config-and-docs.test.ts
+++ b/tests/config-and-docs.test.ts
@@ -138,11 +138,15 @@ describe("config + docs parity", () => {
 		expect(readme).toContain(`"handsFreeQuietThreshold": ${defaults.handsFreeQuietThreshold}`);
 		expect(readme).toContain(`"autoExitGracePeriod": ${defaults.autoExitGracePeriod}`);
 		expect(readme).toContain(`Dispatch defaults \`autoExitOnQuiet: true\` — the session gets a 15s startup grace period`);
-		expect(readme).toContain("The completion notification identifies this as a quiet auto-close, not a user kill.");
+		expect(readme).toContain('completionReason: "auto-close-quiet"');
+		expect(readme).toContain("this is not a terminal command verdict.");
+		expect(readme).toContain("provider-agnostic watch-until-terminal pattern");
 		expect(skill).toContain("enable_interactive_shell");
 		expect(skill).toContain("reloaded, new, resumed, and forked sessions reset it to inactive");
-		expect(skill).toContain("reports that completion reason separately from a user kill");
-		expect(toolSchema).toContain("reports that completion reason separately from a user kill");
+		expect(skill).toContain('completionReason: "auto-close-quiet"');
+		expect(skill).toContain("provider-agnostic external gate watcher");
+		expect(toolSchema).toContain('completionReason: "auto-close-quiet"');
+		expect(toolSchema).toContain("WATCH-UNTIL-TERMINAL RECIPE:");
 		expect(readme).toContain('submit: true');
 		expect(readme).toContain('raw `input` only types text. It does not submit the prompt.');
 		expect(skill).toContain("~8s of quiet");

--- a/tests/headless-monitor.test.ts
+++ b/tests/headless-monitor.test.ts
@@ -91,6 +91,7 @@ describe("HeadlessDispatchMonitor", () => {
 		expect(onComplete).toHaveBeenCalledWith(expect.objectContaining({
 			cancelled: true,
 			autoClosedOnQuiet: true,
+			completionReason: "auto-close-quiet",
 		}));
 	});
 
@@ -124,6 +125,7 @@ describe("HeadlessDispatchMonitor", () => {
 		expect(onComplete).toHaveBeenCalledWith({
 			exitCode: 0,
 			signal: undefined,
+			completionReason: "exited",
 			timedOut: undefined,
 			cancelled: undefined,
 			completionOutput: {
@@ -133,6 +135,23 @@ describe("HeadlessDispatchMonitor", () => {
 			},
 		});
 		expect(monitor.getResult()?.completionOutput?.lines).toEqual(["final"]);
+	});
+
+	it("reports an explicit monitor kill as killed", () => {
+		const session = createSession();
+		const onComplete = vi.fn();
+		const monitor = new HeadlessDispatchMonitor(session, config, {
+			autoExitOnQuiet: false,
+			quietThreshold: 1000,
+		}, onComplete);
+
+		monitor.kill();
+
+		expect(session.kill).toHaveBeenCalledTimes(1);
+		expect(onComplete).toHaveBeenCalledWith(expect.objectContaining({
+			cancelled: true,
+			completionReason: "killed",
+		}));
 	});
 
 	it("emits stream monitor events from ANSI-stripped line output", () => {

--- a/tests/notification-utils.test.ts
+++ b/tests/notification-utils.test.ts
@@ -5,6 +5,7 @@ describe("notification utilities", () => {
 	it("formats compact dispatch notifications with a trimmed tail", () => {
 		const text = buildDispatchNotification("calm-reef", {
 			exitCode: 0,
+			completionReason: "exited",
 			completionOutput: {
 				lines: ["1", "2", "3", "4", "5", "6", ""],
 				totalLines: 6,
@@ -19,19 +20,32 @@ describe("notification utilities", () => {
 	it("distinguishes quiet auto-close from a killed dispatch session", () => {
 		const text = buildDispatchNotification("calm-reef", {
 			exitCode: null,
+			completionReason: "auto-close-quiet",
 			cancelled: true,
 			autoClosedOnQuiet: true,
 		}, "30s");
-		expect(text).toContain("Session calm-reef auto-closed after quiet (30s).");
+		expect(text).toContain("Session calm-reef auto-closed after quiet (30s). This is not a terminal command verdict.");
 		expect(text).not.toContain("was killed");
+		expect(text).not.toContain("completed successfully");
 	});
 
 	it("formats explicitly cancelled dispatch notifications as killed", () => {
 		const text = buildDispatchNotification("calm-reef", {
 			exitCode: null,
+			completionReason: "killed",
 			cancelled: true,
 		}, "30s");
 		expect(text).toContain("Session calm-reef was killed (30s).");
+	});
+
+	it("marks an overlay quiet auto-close as non-terminal", () => {
+		const text = buildResultNotification("calm-reef", {
+			exitCode: null,
+			completionReason: "auto-close-quiet",
+			backgrounded: false,
+			cancelled: true,
+		});
+		expect(text).toContain("This is not a terminal command verdict.");
 	});
 
 	it("formats final result notifications", () => {

--- a/tool-schema.ts
+++ b/tool-schema.ts
@@ -101,8 +101,11 @@ Workflow:
 2. Do other work - no polling needed
 3. When complete, you receive a notification with the session output
 
-Dispatch defaults autoExitOnQuiet to true (opt-out with handsFree.autoExitOnQuiet: false). A quiet TUI auto-closes after the threshold and reports that completion reason separately from a user kill.
+Dispatch defaults autoExitOnQuiet to true (opt-out with handsFree.autoExitOnQuiet: false). A quiet TUI auto-closes after the threshold and reports completionReason: "auto-close-quiet" separately from a user kill. This is not a terminal command verdict.
 You can still query with sessionId if needed, but it's not required.
+
+WATCH-UNTIL-TERMINAL RECIPE:
+For external gates, use mode="monitor" with explicit ready/blocked/stale trigger lines, handsFree: { autoExitOnQuiet: false }, and a timeout. Have the command exit only after it emits a terminal line. This is provider-agnostic: it works with CI, deploy, health, and custom CLI watchers. If raw dispatch is required, set handsFree.autoExitOnQuiet to false and treat completionReason: "auto-close-quiet" as non-terminal.
 
 BACKGROUND DISPATCH (HEADLESS):
 Start a session without any overlay. Process runs headlessly, agent notified on completion:

--- a/types.ts
+++ b/types.ts
@@ -2,9 +2,13 @@
  * Shared types and interfaces for the interactive shell extension.
  */
 
+export type DispatchCompletionReason = "exited" | "timed-out" | "killed" | "auto-close-quiet";
+
 export interface InteractiveShellResult {
 	exitCode: number | null;
 	signal?: number;
+	/** Why a dispatch session completed. `auto-close-quiet` is not a command verdict. */
+	completionReason?: DispatchCompletionReason;
 	backgrounded: boolean;
 	backgroundId?: string;
 	cancelled: boolean;


### PR DESCRIPTION
Closes #37.
Closes #38.

## Summary

This makes dispatch quiet auto-close explicit for watcher-shaped commands. Quiet auto-close now has `completionReason: "auto-close-quiet"`, and notifications say that this is not a terminal command verdict.

Headless explicit kills now route through the dispatch monitor too, so explicit cancellation reports `completionReason: "killed"` instead of looking like a natural exit.

It also documents a provider-agnostic watch-until-terminal recipe that uses monitor mode, explicit terminal trigger lines, disabled quiet auto-close, and a hard timeout.

## Validation

- `npm test -- --run tests/headless-monitor.test.ts tests/notification-utils.test.ts tests/config-and-docs.test.ts tests/monitor-mode.test.ts`
- `npm run typecheck`
- `git diff --check`
- Fresh exact-head review for `23cdb3275c410652f909004ca3ad5c84f385cfd4`: No issues found.
