### PR TITLE
Require explicit opt-in for dispatch quiet auto-exit

### DIFF
--- a/.agents/friction-log/20260826011232-pnpm-test-implicit/friction.md
+++ b/.agents/friction-log/20260826011232-pnpm-test-implicit/friction.md
@@ -1,0 +1,6 @@
+---
+title: 'pnpm test implicit install blocked'
+severity: 'minor'
+---
+
+In the pi-interactive-shell task worktree, running pnpm test with no node_modules caused pnpm 11 to run an implicit install. It downloaded packages but exited non-zero because build scripts were ignored (ERR_PNPM_IGNORED_BUILDS), so focused tests did not start. Reproduction: fresh worktree without node_modules; run pnpm test -- tests/dispatch-auto-exit.test.ts.

--- a/.agents/friction-log/20260826011232-pnpm-test-implicit/friction.md
+++ b/.agents/friction-log/20260826011232-pnpm-test-implicit/friction.md
@@ -1,6 +1,0 @@
----
-title: 'pnpm test implicit install blocked'
-severity: 'minor'
----
-
-In the pi-interactive-shell task worktree, running pnpm test with no node_modules caused pnpm 11 to run an implicit install. It downloaded packages but exited non-zero because build scripts were ignored (ERR_PNPM_IGNORED_BUILDS), so focused tests did not start. Reproduction: fresh worktree without node_modules; run pnpm test -- tests/dispatch-auto-exit.test.ts.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to the `pi-interactive-shell` extension will be documented i
 
 ## [Unreleased]
 
+### Fixed
+- Keep dispatch sessions alive through quiet output by default; quiet auto-exit now requires explicit opt-in so coding-agent workers are not killed while still running.
+
 ## [0.14.1] - 2026-08-09
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ Attach to review full output: interactive_shell({ attach: "calm-reef" })
 
 The notification includes a brief tail (last 5 lines) and a reattach instruction. The PTY is preserved for 5 minutes so the agent can attach to review full scrollback.
 
-Dispatch defaults `autoExitOnQuiet: true` — the session gets a 15s startup grace period, then auto-closes after output goes silent (8s by default). The completion notification identifies this as a quiet auto-close, not a user kill. Tune the grace period with `handsFree: { gracePeriod: 60000 }` or opt out entirely with `handsFree: { autoExitOnQuiet: false }`.
+Dispatch waits for process exit by default, so a quiet coding agent can continue reasoning or using tools without being killed. Enable `handsFree: { autoExitOnQuiet: true }` only when silence is an explicit completion condition; the completion notification identifies that as a quiet auto-close rather than a user kill.
 
 The overlay still shows for the user, who can Ctrl+T to transfer output, Ctrl+B to background, take over by typing, or Ctrl+Q for more options. `Ctrl+G` only becomes meaningful after the user has taken over a monitored hands-free or dispatch session.
 

--- a/index.ts
+++ b/index.ts
@@ -881,7 +881,7 @@ export default function interactiveShellExtension(pi: ExtensionAPI) {
 			sessionManager.add(launchCommand, session, name, effectiveReason, { id, noAutoCleanup: true, startedAt: new Date(startTime) });
 
 			const monitor = new HeadlessDispatchMonitor(session, config, {
-				autoExitOnQuiet: handsFree?.autoExitOnQuiet !== false,
+				autoExitOnQuiet: handsFree?.autoExitOnQuiet === true,
 				quietThreshold: handsFree?.quietThreshold ?? config.handsFreeQuietThreshold,
 				gracePeriod: handsFree?.gracePeriod ?? config.autoExitGracePeriod,
 				timeout,
@@ -923,9 +923,7 @@ export default function interactiveShellExtension(pi: ExtensionAPI) {
 							handsFreeQuietThreshold: handsFree?.quietThreshold,
 							handsFreeUpdateMaxChars: handsFree?.updateMaxChars,
 							handsFreeMaxTotalChars: handsFree?.maxTotalChars,
-							autoExitOnQuiet: effectiveMode === "dispatch"
-								? handsFree?.autoExitOnQuiet !== false
-								: effectiveMode === "hands-free" && handsFree?.autoExitOnQuiet === true,
+							autoExitOnQuiet: handsFree?.autoExitOnQuiet === true,
 							autoExitGracePeriod: handsFree?.gracePeriod ?? config.autoExitGracePeriod,
 							onUnfocus: () => coordinator.unfocusOverlay(),
 							onHandsFreeUpdate: effectiveMode === "hands-free"
@@ -1524,9 +1522,7 @@ export default function interactiveShellExtension(pi: ExtensionAPI) {
 								handsFreeQuietThreshold: handsFree?.quietThreshold,
 								handsFreeUpdateMaxChars: handsFree?.updateMaxChars,
 								handsFreeMaxTotalChars: handsFree?.maxTotalChars,
-								autoExitOnQuiet: mode === "dispatch"
-									? handsFree?.autoExitOnQuiet !== false
-									: handsFree?.autoExitOnQuiet === true,
+								autoExitOnQuiet: handsFree?.autoExitOnQuiet === true,
 								autoExitGracePeriod: handsFree?.gracePeriod ?? config.autoExitGracePeriod,
 								onUnfocus: () => coordinator.unfocusOverlay(),
 								onHandsFreeUpdate: mode === "hands-free"
@@ -1903,7 +1899,7 @@ function setupDispatchCompletion(
 			const remainingTimeout = ctx.timeout ? Math.max(0, ctx.timeout - elapsed) : undefined;
 			const bgStartTime = bgSession.startedAt.getTime();
 			const monitor = new HeadlessDispatchMonitor(bgSession.session, config, {
-				autoExitOnQuiet: ctx.handsFree?.autoExitOnQuiet !== false,
+				autoExitOnQuiet: ctx.handsFree?.autoExitOnQuiet === true,
 				quietThreshold: ctx.handsFree?.quietThreshold ?? config.handsFreeQuietThreshold,
 				gracePeriod: ctx.handsFree?.gracePeriod ?? config.autoExitGracePeriod,
 				timeout: remainingTimeout,

--- a/index.ts
+++ b/index.ts
@@ -1374,7 +1374,9 @@ export default function interactiveShellExtension(pi: ExtensionAPI) {
 						const truncatedNote = truncated ? ` (${totalBytes} bytes total, truncated)` : "";
 						const hasOutput = output.length > 0;
 						const hasMoreNote = hasMore === true ? " (more available)" : "";
-						sessionManager.unregisterActive(sessionId, !result.backgrounded);
+						if (!session.retainAfterCompletion || result.backgrounded) {
+							sessionManager.unregisterActive(sessionId, !result.backgrounded);
+						}
 						return {
 							content: [{ type: "text", text: `Session ${sessionId} ${status} after ${formatDurationMs(runtime)}${hasOutput ? `\n\nOutput${truncatedNote}${hasMoreNote}:\n${output}` : ""}` }],
 							details: { sessionId, status, runtime, output, outputTruncated: truncated, outputTotalBytes: totalBytes, outputTotalLines: totalLines, hasMore, exitCode: result.exitCode, signal: result.signal, backgroundId: result.backgroundId },
@@ -1403,7 +1405,9 @@ export default function interactiveShellExtension(pi: ExtensionAPI) {
 							const hasOutput = output.length > 0;
 							const hasMoreNote = hasMore === true ? " (more available)" : "";
 							if (earlyResult) {
-								sessionManager.unregisterActive(sessionId, !earlyResult.backgrounded);
+								if (!earlySession.retainAfterCompletion || earlyResult.backgrounded) {
+									sessionManager.unregisterActive(sessionId, !earlyResult.backgrounded);
+								}
 								return {
 									content: [{ type: "text", text: `Session ${sessionId} ${earlyStatus} after ${formatDurationMs(earlyRuntime)}${hasOutput ? `\n\nOutput${truncatedNote}${hasMoreNote}:\n${output}` : ""}` }],
 									details: { sessionId, status: earlyStatus, runtime: earlyRuntime, output, outputTruncated: truncated, outputTotalBytes: totalBytes, outputTotalLines: totalLines, hasMore, exitCode: earlyResult.exitCode, signal: earlyResult.signal, backgroundId: earlyResult.backgroundId },
@@ -1423,7 +1427,9 @@ export default function interactiveShellExtension(pi: ExtensionAPI) {
 						const freshRuntime = session.getRuntime();
 						const freshResult = session.getResult();
 						if (freshResult) {
-							sessionManager.unregisterActive(sessionId, !freshResult.backgrounded);
+							if (!session.retainAfterCompletion || freshResult.backgrounded) {
+								sessionManager.unregisterActive(sessionId, !freshResult.backgrounded);
+							}
 							return {
 								content: [{ type: "text", text: `Session ${sessionId} ${freshStatus} after ${formatDurationMs(freshRuntime)}${hasOutput ? `\n\nOutput${truncatedNote}${hasMoreNote}:\n${freshOutput.output}` : ""}` }],
 								details: { sessionId, status: freshStatus, runtime: freshRuntime, output: freshOutput.output, outputTruncated: freshOutput.truncated, outputTotalBytes: freshOutput.totalBytes, outputTotalLines: freshOutput.totalLines, hasMore: freshOutput.hasMore, exitCode: freshResult.exitCode, signal: freshResult.signal, backgroundId: freshResult.backgroundId },
@@ -1916,7 +1922,7 @@ function setupDispatchCompletion(
 					customType: "interactive-shell-transfer",
 					content,
 					display: true,
-					details: { sessionId: id, exitCode: result.exitCode, signal: result.signal, timedOut: result.timedOut, cancelled: result.cancelled, completionOutput: result.completionOutput },
+					details: { sessionId: id, exitCode: result.exitCode, signal: result.signal, timedOut: result.timedOut, cancelled: result.cancelled, autoClosedOnQuiet: result.autoClosedOnQuiet, completionOutput: result.completionOutput },
 				}, { triggerTurn: true });
 			}
 			pi.events.emit("interactive-shell:transfer", {
@@ -1926,8 +1932,9 @@ function setupDispatchCompletion(
 				signal: result.signal,
 				timedOut: result.timedOut,
 				cancelled: result.cancelled,
+				autoClosedOnQuiet: result.autoClosedOnQuiet,
 			});
-			sessionManager.unregisterActive(id, true);
+			sessionManager.scheduleActiveCleanup(id, 5 * 60 * 1000);
 			coordinator.disposeMonitor(id);
 			return;
 		}

--- a/notification-utils.ts
+++ b/notification-utils.ts
@@ -145,6 +145,7 @@ function buildDispatchStatusLine(sessionId: string, info: HeadlessCompletionInfo
 
 function buildResultStatusLine(sessionId: string, result: InteractiveShellResult): string {
 	if (result.timedOut) return `Session ${sessionId} timed out.`;
+	if (result.autoClosedOnQuiet) return `Session ${sessionId} auto-closed after quiet.`;
 	if (result.cancelled) return `Session ${sessionId} was killed.`;
 	if (result.exitCode === 0) return `Session ${sessionId} completed successfully.`;
 	return `Session ${sessionId} exited with code ${result.exitCode}.`;
@@ -158,6 +159,7 @@ function buildInteractiveSummary(result: InteractiveShellResult, timeout?: numbe
 	if (result.backgrounded) {
 		return `Session running in background (id: ${result.backgroundId}). User can reattach with /attach ${result.backgroundId}`;
 	}
+	if (result.autoClosedOnQuiet) return "Session auto-closed after quiet";
 	if (result.cancelled) return "User killed the interactive session";
 	if (result.timedOut) return `Session killed after timeout (${timeout ?? "?"}ms)`;
 	const status = result.exitCode === 0 ? "successfully" : `with code ${result.exitCode}`;

--- a/overlay-component.ts
+++ b/overlay-component.ts
@@ -165,6 +165,8 @@ export class InteractiveShellOverlay implements Component, Focusable {
 				getStatus: () => this.getSessionStatus(),
 				getRuntime: () => this.getRuntime(),
 				getResult: () => this.getCompletionResult(),
+				retainAfterCompletion: options.mode === "dispatch",
+				dispose: () => this.session.dispose(),
 				setUpdateInterval: (intervalMs) => this.setUpdateInterval(intervalMs),
 				setQuietThreshold: (thresholdMs) => this.setQuietThreshold(thresholdMs),
 				onComplete: (callback) => this.registerCompleteCallback(callback),
@@ -216,8 +218,9 @@ export class InteractiveShellOverlay implements Component, Focusable {
 	}
 
 	/** Get current session status */
-	getSessionStatus(): "running" | "user-takeover" | "exited" | "killed" | "backgrounded" {
+	getSessionStatus(): "running" | "user-takeover" | "exited" | "killed" | "auto-closed-on-quiet" | "backgrounded" {
 		if (this.completionResult) {
+			if (this.completionResult.autoClosedOnQuiet) return "auto-closed-on-quiet";
 			if (this.completionResult.cancelled) return "killed";
 			if (this.completionResult.backgrounded) return "backgrounded";
 			if (this.userTookOver) return "user-takeover";
@@ -353,8 +356,7 @@ export class InteractiveShellOverlay implements Component, Focusable {
 						this.emitHandsFreeUpdate();
 						this.hasUnsentData = false;
 					}
-					// Send completion notification and auto-close
-					// Use "killed" status since we're forcibly terminating (matches finishWithKill's cancelled=true)
+					// Send completion notification and auto-close.
 					if (this.options.onHandsFreeUpdate && this.sessionId) {
 						this.options.onHandsFreeUpdate({
 							status: "killed",
@@ -366,7 +368,7 @@ export class InteractiveShellOverlay implements Component, Focusable {
 							budgetExhausted: this.budgetExhausted,
 						});
 					}
-					this.finishWithKill();
+					this.finishWithQuietAutoClose();
 					return;
 				}
 				// Normal behavior: just emit update
@@ -555,6 +557,8 @@ export class InteractiveShellOverlay implements Component, Focusable {
 				getStatus: () => this.getSessionStatus(),
 				getRuntime: () => this.getRuntime(),
 				getResult: () => this.getCompletionResult(),
+				retainAfterCompletion: this.options.mode === "dispatch",
+				dispose: () => this.session.dispose(),
 				setUpdateInterval: (intervalMs) => this.setUpdateInterval(intervalMs),
 				setQuietThreshold: (thresholdMs) => this.setQuietThreshold(thresholdMs),
 				onComplete: (callback) => this.registerCompleteCallback(callback),
@@ -713,6 +717,41 @@ export class InteractiveShellOverlay implements Component, Focusable {
 
 		// In streaming mode (blocking tool call), unregister now since the agent
 		// gets the result via tool return. Otherwise keep registered for queries.
+		if (this.options.streamingMode) {
+			this.unregisterActiveSession(true);
+		}
+
+		this.done(result);
+	}
+
+	private finishWithQuietAutoClose(): void {
+		if (this.finished) return;
+		this.finished = true;
+		this.stopCountdown();
+		this.stopTimeout();
+		this.stopHandsFreeUpdates();
+
+		const handoffPreview = this.maybeBuildHandoffPreview("kill");
+		const handoff = this.maybeWriteHandoffSnapshot("kill");
+		const completionOutput = this.captureCompletionOutput();
+		this.session.kill();
+		if (this.options.mode !== "dispatch") {
+			this.session.dispose();
+		}
+		const result: InteractiveShellResult = {
+			exitCode: null,
+			backgrounded: false,
+			cancelled: true,
+			autoClosedOnQuiet: true,
+			sessionId: this.sessionId ?? undefined,
+			userTookOver: this.userTookOver,
+			completionOutput,
+			handoffPreview,
+			handoff,
+		};
+		this.completionResult = result;
+		this.triggerCompleteCallbacks();
+
 		if (this.options.streamingMode) {
 			this.unregisterActiveSession(true);
 		}

--- a/session-manager.ts
+++ b/session-manager.ts
@@ -9,7 +9,7 @@ export interface BackgroundSession {
 	startedAt: Date;
 }
 
-export type ActiveSessionStatus = "running" | "monitoring" | "user-takeover" | "exited" | "killed" | "backgrounded";
+export type ActiveSessionStatus = "running" | "monitoring" | "user-takeover" | "exited" | "killed" | "auto-closed-on-quiet" | "backgrounded";
 
 export interface ActiveSessionResult {
 	exitCode: number | null;
@@ -18,6 +18,7 @@ export interface ActiveSessionResult {
 	backgroundId?: string;
 	cancelled?: boolean;
 	timedOut?: boolean;
+	autoClosedOnQuiet?: boolean;
 }
 
 export interface OutputResult {
@@ -52,6 +53,10 @@ export interface ActiveSession {
 	getStatus: () => ActiveSessionStatus;
 	getRuntime: () => number;
 	getResult: () => ActiveSessionResult | undefined;
+	/** Keep completed dispatch output available until its retention cleanup runs. */
+	retainAfterCompletion?: boolean;
+	/** Release retained terminal resources when their retention period expires. */
+	dispose?: () => void;
 	setUpdateInterval?: (intervalMs: number) => void;
 	setQuietThreshold?: (thresholdMs: number) => void;
 	onComplete: (callback: () => void) => void;
@@ -137,6 +142,7 @@ export class ShellSessionManager {
 	private exitWatchers = new Map<string, NodeJS.Timeout>();
 	private cleanupTimers = new Map<string, NodeJS.Timeout>();
 	private activeSessions = new Map<string, ActiveSession>();
+	private activeCleanupTimers = new Map<string, NodeJS.Timeout>();
 	private changeListeners = new Set<() => void>();
 
 	onChange(listener: () => void): () => void {
@@ -155,10 +161,20 @@ export class ShellSessionManager {
 	}
 
 	registerActive(session: ActiveSession): void {
+		const cleanupTimer = this.activeCleanupTimers.get(session.id);
+		if (cleanupTimer) {
+			clearTimeout(cleanupTimer);
+			this.activeCleanupTimers.delete(session.id);
+		}
 		this.activeSessions.set(session.id, session);
 	}
 
 	unregisterActive(id: string, releaseId = false): void {
+		const cleanupTimer = this.activeCleanupTimers.get(id);
+		if (cleanupTimer) {
+			clearTimeout(cleanupTimer);
+			this.activeCleanupTimers.delete(id);
+		}
 		this.activeSessions.delete(id);
 		// Only release the ID if explicitly requested (when session fully terminates)
 		// This prevents ID reuse while session is still running after takeover
@@ -169,6 +185,20 @@ export class ShellSessionManager {
 
 	getActive(id: string): ActiveSession | undefined {
 		return this.activeSessions.get(id);
+	}
+
+	scheduleActiveCleanup(id: string, delayMs: number): void {
+		if (this.activeCleanupTimers.has(id)) return;
+		const timer = setTimeout(() => {
+			this.activeCleanupTimers.delete(id);
+			const session = this.activeSessions.get(id);
+			try {
+				session?.dispose?.();
+			} finally {
+				this.unregisterActive(id, true);
+			}
+		}, delayMs);
+		this.activeCleanupTimers.set(id, timer);
 	}
 
 	writeToActive(id: string, data: string): boolean {

--- a/skills/pi-interactive-shell/SKILL.md
+++ b/skills/pi-interactive-shell/SKILL.md
@@ -113,7 +113,7 @@ interactive_shell({
 // → Do other work. When session completes, you receive notification with output.
 ```
 
-Dispatch defaults `autoExitOnQuiet: true`. A quiet TUI auto-closes after the threshold and reports that completion reason separately from a user kill. The agent can still query the sessionId if needed, but doesn't have to.
+Dispatch waits for process exit by default. Enable `handsFree.autoExitOnQuiet` only when silence is an explicit completion condition; quiet coding agents may still be reasoning or using tools. Quiet auto-close reports that completion reason separately from a user kill.
 
 For fire-and-forget delegated runs (including QA-style delegated checks), prefer dispatch as the default mode.
 

--- a/tests/config-and-docs.test.ts
+++ b/tests/config-and-docs.test.ts
@@ -133,10 +133,10 @@ describe("config + docs parity", () => {
 		expect(readme).toContain("Alt+Shift+P");
 		expect(readme).toContain(`"handsFreeQuietThreshold": ${defaults.handsFreeQuietThreshold}`);
 		expect(readme).toContain(`"autoExitGracePeriod": ${defaults.autoExitGracePeriod}`);
-		expect(readme).toContain(`Dispatch defaults \`autoExitOnQuiet: true\` — the session gets a 15s startup grace period`);
-		expect(readme).toContain("The completion notification identifies this as a quiet auto-close, not a user kill.");
+		expect(readme).toContain("Dispatch waits for process exit by default");
+		expect(readme).toContain("the completion notification identifies that as a quiet auto-close rather than a user kill");
 		expect(skill).toContain("reports that completion reason separately from a user kill");
-		expect(toolSchema).toContain("reports that completion reason separately from a user kill");
+		expect(toolSchema).toContain("Dispatch waits for process exit by default");
 		expect(readme).toContain('submit: true');
 		expect(readme).toContain('raw `input` only types text. It does not submit the prompt.');
 		expect(skill).toContain("~8s of quiet");

--- a/tests/dispatch-auto-exit.test.ts
+++ b/tests/dispatch-auto-exit.test.ts
@@ -1,0 +1,221 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+type OverlayOptions = { autoExitOnQuiet?: boolean };
+type MonitorOptions = { autoExitOnQuiet: boolean };
+
+async function setupHarness() {
+	let toolDef: any;
+	let nextId = 0;
+	let nextOverlayResult: Promise<any> = new Promise(() => {});
+	const overlayOptions: OverlayOptions[] = [];
+	const monitorOptions: MonitorOptions[] = [];
+	const backgroundSession = {
+		id: "background-session",
+		command: "pi",
+		session: { exited: false, setEventHandlers: vi.fn() },
+		startedAt: new Date(),
+	};
+	const attachedSession = {
+		id: "attached-session",
+		command: "pi",
+		session: { exited: false, setEventHandlers: vi.fn() },
+		startedAt: new Date(),
+	};
+
+	vi.resetModules();
+	vi.doMock("@earendil-works/pi-coding-agent", () => ({ getAgentDir: () => "/tmp/pi-agent" }));
+	vi.doMock("@earendil-works/pi-tui", () => ({
+		isKeyRelease: () => false,
+		isKeyRepeat: () => false,
+		matchesKey: () => false,
+		truncateToWidth: (value: string) => value,
+		visibleWidth: (value: string) => value.length,
+	}));
+	vi.doMock("../config.ts", async () => {
+		const actual = await vi.importActual<typeof import("../config.ts")>("../config.ts");
+		return {
+			...actual,
+			loadConfig: vi.fn(() => ({
+				exitAutoCloseDelay: 10,
+				overlayWidthPercent: 95,
+				overlayHeightPercent: 60,
+				overlayAnchor: "center",
+				focusShortcut: "alt+shift+f",
+				spawn: { defaultAgent: "pi", shortcut: "alt+shift+p", commands: { pi: "pi" }, defaultArgs: { pi: [] }, worktree: false },
+				scrollbackLines: 5000,
+				ansiReemit: true,
+				handoffPreviewEnabled: true,
+				handoffPreviewLines: 30,
+				handoffPreviewMaxChars: 2000,
+				handoffSnapshotEnabled: false,
+				handoffSnapshotLines: 200,
+				handoffSnapshotMaxChars: 12000,
+				transferLines: 200,
+				transferMaxChars: 20000,
+				completionNotifyLines: 50,
+				completionNotifyMaxChars: 5000,
+				handsFreeUpdateMode: "on-quiet",
+				handsFreeUpdateInterval: 60000,
+				handsFreeQuietThreshold: 8000,
+				autoExitGracePeriod: 15000,
+				handsFreeUpdateMaxChars: 1500,
+				handsFreeMaxTotalChars: 100000,
+				minQueryIntervalSeconds: 60,
+			})),
+		};
+	});
+	vi.doMock("../overlay-component.ts", () => ({
+		InteractiveShellOverlay: class MockInteractiveShellOverlay {
+			constructor(_tui: unknown, _theme: unknown, options: OverlayOptions) {
+				overlayOptions.push(options);
+			}
+		},
+	}));
+	vi.doMock("../reattach-overlay.ts", () => ({ ReattachOverlay: class MockReattachOverlay {} }));
+	vi.doMock("../pty-session.ts", () => ({
+		PtyTerminalSession: class MockPtyTerminalSession {
+			exited = false;
+			exitCode: number | null = null;
+			signal: number | undefined;
+			addDataListener() { return () => {}; }
+			addExitListener() { return () => {}; }
+			getTailLines() { return { lines: [], totalLinesInBuffer: 0, truncatedByChars: false }; }
+			getRawStream() { return ""; }
+			kill() {}
+			setEventHandlers() {}
+		}
+	}));
+	vi.doMock("../headless-monitor.ts", () => ({
+		HeadlessDispatchMonitor: class MockHeadlessDispatchMonitor {
+			disposed = false;
+			constructor(_session: unknown, _config: unknown, options: MonitorOptions) {
+				monitorOptions.push(options);
+			}
+			getResult() { return undefined; }
+			registerCompleteCallback() {}
+			dispose() { this.disposed = true; }
+		},
+	}));
+	vi.doMock("../session-manager.ts", () => ({
+		sessionManager: {
+			getActive: vi.fn(() => undefined),
+			unregisterActive: vi.fn(),
+			registerActive: vi.fn(),
+			list: vi.fn(() => []),
+			add: vi.fn(),
+			take: vi.fn((id: string) => id === attachedSession.id ? attachedSession : undefined),
+			get: vi.fn((id: string) => id === backgroundSession.id ? backgroundSession : undefined),
+			restore: vi.fn(),
+			remove: vi.fn(),
+			scheduleCleanup: vi.fn(),
+			restartAutoCleanup: vi.fn(),
+			killAll: vi.fn(),
+			onChange: vi.fn(() => () => {}),
+			setActiveUpdateInterval: vi.fn(() => false),
+			setActiveQuietThreshold: vi.fn(() => false),
+			writeToActive: vi.fn(() => false),
+		},
+		generateSessionId: vi.fn(() => `session-${++nextId}`),
+	}));
+	vi.doMock("../runtime-coordinator.ts", () => ({
+		InteractiveShellCoordinator: class MockCoordinator {
+			markAgentHandledCompletion = vi.fn();
+			consumeAgentHandledCompletion = vi.fn(() => false);
+			getMonitor = vi.fn(() => undefined);
+			focusOverlay = vi.fn();
+			unfocusOverlay = vi.fn();
+			setOverlayHandle = vi.fn();
+			clearOverlayHandle = vi.fn();
+			isOverlayOpen = vi.fn(() => false);
+			beginOverlay = vi.fn(() => true);
+			endOverlay = vi.fn();
+			replaceBackgroundWidgetCleanup = vi.fn();
+			clearBackgroundWidget = vi.fn();
+			disposeAllMonitors = vi.fn();
+			disposeMonitor = vi.fn();
+			deleteMonitor = vi.fn();
+			setMonitor = vi.fn();
+			registerMonitorSession = vi.fn();
+		},
+	}));
+
+	const extensionModule = await import("../index.ts");
+	extensionModule.default({
+		registerShortcut: vi.fn(),
+		registerCommand: vi.fn(),
+		registerTool: vi.fn((definition: any) => { toolDef = definition; }),
+		on: vi.fn(),
+		events: { emit: vi.fn() },
+		sendMessage: vi.fn(),
+	} as any);
+
+	const context = {
+		hasUI: true,
+		cwd: "/tmp/project",
+		ui: {
+			custom: vi.fn((_factory: (tui: unknown, theme: unknown, kb: unknown, done: unknown) => unknown) => {
+				_factory({}, {}, {}, () => {});
+				return nextOverlayResult;
+			}),
+		},
+		sessionManager: { getSessionFile: () => "/tmp/project/session.jsonl" },
+	} as any;
+
+	return {
+		toolDef,
+		context,
+		overlayOptions,
+		monitorOptions,
+		setOverlayResult: (result: Promise<any>) => { nextOverlayResult = result; },
+		backgroundSession,
+	};
+}
+
+describe("dispatch quiet auto-exit", () => {
+	afterEach(() => {
+		vi.doUnmock("@earendil-works/pi-coding-agent");
+		vi.doUnmock("@earendil-works/pi-tui");
+		vi.doUnmock("../config.ts");
+		vi.doUnmock("../overlay-component.ts");
+		vi.doUnmock("../reattach-overlay.ts");
+		vi.doUnmock("../pty-session.ts");
+		vi.doUnmock("../headless-monitor.ts");
+		vi.doUnmock("../session-manager.ts");
+		vi.doUnmock("../runtime-coordinator.ts");
+	});
+
+	it("waits for exit by default across monitor, headless, foreground, reattach, and handoff paths", async () => {
+		const harness = await setupHarness();
+
+		await harness.toolDef.execute("monitor", {
+			command: "tail -f log",
+			mode: "monitor",
+			monitor: { strategy: "stream", triggers: [{ id: "error", literal: "ERROR" }] },
+		}, undefined, undefined, { ...harness.context, hasUI: false });
+		await harness.toolDef.execute("headless", { command: "pi", mode: "dispatch", background: true }, undefined, undefined, harness.context);
+		expect(harness.monitorOptions.map((options) => options.autoExitOnQuiet)).toEqual([false, false]);
+
+		await harness.toolDef.execute("foreground", { command: "pi", mode: "dispatch" }, undefined, undefined, harness.context);
+		await harness.toolDef.execute("reattach", { attach: "attached-session", mode: "dispatch" }, undefined, undefined, harness.context);
+		expect(harness.overlayOptions.map((options) => options.autoExitOnQuiet)).toEqual([false, false]);
+
+		harness.setOverlayResult(Promise.resolve({ backgrounded: true, backgroundId: harness.backgroundSession.id, cancelled: false, exitCode: null }));
+		await harness.toolDef.execute("handoff", { command: "pi", mode: "dispatch" }, undefined, undefined, harness.context);
+		await Promise.resolve();
+		await Promise.resolve();
+		expect(harness.monitorOptions.at(-1)?.autoExitOnQuiet).toBe(false);
+	});
+
+	it("enables quiet auto-exit only when explicitly requested", async () => {
+		const harness = await setupHarness();
+		await harness.toolDef.execute("headless", {
+			command: "pi",
+			mode: "dispatch",
+			background: true,
+			handsFree: { autoExitOnQuiet: true },
+		}, undefined, undefined, harness.context);
+
+		expect(harness.monitorOptions).toHaveLength(1);
+		expect(harness.monitorOptions[0]?.autoExitOnQuiet).toBe(true);
+	});
+});

--- a/tests/dispatch-auto-exit.test.ts
+++ b/tests/dispatch-auto-exit.test.ts
@@ -9,6 +9,7 @@ async function setupHarness() {
 	let nextOverlayResult: Promise<any> = new Promise(() => {});
 	const overlayOptions: OverlayOptions[] = [];
 	const monitorOptions: MonitorOptions[] = [];
+	const activeSessions = new Map<string, any>();
 	const backgroundSession = {
 		id: "background-session",
 		command: "pi",
@@ -96,25 +97,27 @@ async function setupHarness() {
 			dispose() { this.disposed = true; }
 		},
 	}));
+	const sessionManager = {
+		getActive: vi.fn((id: string) => activeSessions.get(id)),
+		unregisterActive: vi.fn((id: string) => { activeSessions.delete(id); }),
+		registerActive: vi.fn((session: any) => { activeSessions.set(session.id, session); }),
+		list: vi.fn(() => []),
+		add: vi.fn(),
+		take: vi.fn((id: string) => id === attachedSession.id ? attachedSession : undefined),
+		get: vi.fn((id: string) => id === backgroundSession.id ? backgroundSession : undefined),
+		restore: vi.fn(),
+		remove: vi.fn(),
+		scheduleCleanup: vi.fn(),
+		scheduleActiveCleanup: vi.fn(),
+		restartAutoCleanup: vi.fn(),
+		killAll: vi.fn(),
+		onChange: vi.fn(() => () => {}),
+		setActiveUpdateInterval: vi.fn(() => false),
+		setActiveQuietThreshold: vi.fn(() => false),
+		writeToActive: vi.fn(() => false),
+	};
 	vi.doMock("../session-manager.ts", () => ({
-		sessionManager: {
-			getActive: vi.fn(() => undefined),
-			unregisterActive: vi.fn(),
-			registerActive: vi.fn(),
-			list: vi.fn(() => []),
-			add: vi.fn(),
-			take: vi.fn((id: string) => id === attachedSession.id ? attachedSession : undefined),
-			get: vi.fn((id: string) => id === backgroundSession.id ? backgroundSession : undefined),
-			restore: vi.fn(),
-			remove: vi.fn(),
-			scheduleCleanup: vi.fn(),
-			restartAutoCleanup: vi.fn(),
-			killAll: vi.fn(),
-			onChange: vi.fn(() => () => {}),
-			setActiveUpdateInterval: vi.fn(() => false),
-			setActiveQuietThreshold: vi.fn(() => false),
-			writeToActive: vi.fn(() => false),
-		},
+		sessionManager,
 		generateSessionId: vi.fn(() => `session-${++nextId}`),
 	}));
 	vi.doMock("../runtime-coordinator.ts", () => ({
@@ -139,6 +142,7 @@ async function setupHarness() {
 		},
 	}));
 
+	const sendMessage = vi.fn();
 	const extensionModule = await import("../index.ts");
 	extensionModule.default({
 		registerShortcut: vi.fn(),
@@ -146,7 +150,7 @@ async function setupHarness() {
 		registerTool: vi.fn((definition: any) => { toolDef = definition; }),
 		on: vi.fn(),
 		events: { emit: vi.fn() },
-		sendMessage: vi.fn(),
+		sendMessage,
 	} as any);
 
 	const context = {
@@ -168,6 +172,9 @@ async function setupHarness() {
 		monitorOptions,
 		setOverlayResult: (result: Promise<any>) => { nextOverlayResult = result; },
 		backgroundSession,
+		sessionManager,
+		setActiveSession: (id: string, session: any) => { activeSessions.set(id, session); },
+		sendMessage,
 	};
 }
 
@@ -204,6 +211,43 @@ describe("dispatch quiet auto-exit", () => {
 		await Promise.resolve();
 		await Promise.resolve();
 		expect(harness.monitorOptions.at(-1)?.autoExitOnQuiet).toBe(false);
+	});
+
+	it.each([
+		["foreground", { command: "pi", mode: "dispatch", handsFree: { autoExitOnQuiet: true } }, "session-1"],
+		["reattach", { attach: "attached-session", mode: "dispatch", handsFree: { autoExitOnQuiet: true } }, "attached-session"],
+	])("reports and retains an explicit quiet close for %s dispatch", async (_path, params, sessionId) => {
+		const harness = await setupHarness();
+		harness.setOverlayResult(Promise.resolve({
+			exitCode: null,
+			backgrounded: false,
+			cancelled: true,
+			autoClosedOnQuiet: true,
+			completionOutput: { lines: ["final output"], totalLines: 1, truncated: false },
+		}));
+
+		await harness.toolDef.execute("quiet", params, undefined, undefined, harness.context);
+		await Promise.resolve();
+		await Promise.resolve();
+
+		expect(harness.overlayOptions.at(-1)?.autoExitOnQuiet).toBe(true);
+		expect(harness.sendMessage).toHaveBeenCalledWith(
+			expect.objectContaining({ content: expect.stringContaining("auto-closed after quiet") }),
+			expect.any(Object),
+		);
+		expect(harness.sessionManager.scheduleActiveCleanup).toHaveBeenCalledWith(sessionId, 5 * 60 * 1000);
+
+		harness.setActiveSession(sessionId, {
+			getOutput: vi.fn(() => ({ output: "final output", truncated: false, totalBytes: 12 })),
+			getStatus: vi.fn(() => "auto-closed-on-quiet"),
+			getRuntime: vi.fn(() => 100),
+			getResult: vi.fn(() => ({ cancelled: true, autoClosedOnQuiet: true })),
+			retainAfterCompletion: true,
+		});
+		const query = await harness.toolDef.execute("query", { sessionId }, undefined, undefined, harness.context);
+		expect(query.content[0].text).toContain("final output");
+		expect(query.details.status).toBe("auto-closed-on-quiet");
+		expect(harness.sessionManager.unregisterActive).not.toHaveBeenCalledWith(sessionId, true);
 	});
 
 	it("enables quiet auto-exit only when explicitly requested", async () => {

--- a/tests/dispatch-lifecycle.test.ts
+++ b/tests/dispatch-lifecycle.test.ts
@@ -1,0 +1,50 @@
+import { expect, it } from "vitest";
+import type { InteractiveShellConfig } from "../config.ts";
+import { HeadlessDispatchMonitor, type HeadlessCompletionInfo } from "../headless-monitor.ts";
+import { PtyTerminalSession } from "../pty-session.ts";
+
+const config = {
+	completionNotifyLines: 20,
+	completionNotifyMaxChars: 2000,
+	autoExitGracePeriod: 0,
+} as InteractiveShellConfig;
+
+function monitorProcess(autoExitOnQuiet: boolean, script: string) {
+	const session = new PtyTerminalSession({
+		command: `${JSON.stringify(process.execPath)} -e ${JSON.stringify(script)}`,
+		cwd: "/tmp",
+		cols: 80,
+		rows: 24,
+		scrollback: 100,
+	});
+	const completion = new Promise<HeadlessCompletionInfo>((resolve) => {
+		new HeadlessDispatchMonitor(session, config, {
+			autoExitOnQuiet,
+			quietThreshold: 75,
+			gracePeriod: 0,
+		}, resolve);
+	});
+	return { session, completion };
+}
+
+it("waits through quiet PTY output by default and retains explicit quiet auto-close", async () => {
+	const startedAt = Date.now();
+	const natural = monitorProcess(false, "process.stdout.write('started\\n'); setTimeout(() => process.exit(0), 300)");
+	try {
+		const result = await natural.completion;
+		expect(Date.now() - startedAt).toBeGreaterThanOrEqual(150);
+		expect(result).toMatchObject({ exitCode: 0 });
+		expect(result.cancelled).not.toBe(true);
+		expect(result.autoClosedOnQuiet).not.toBe(true);
+	} finally {
+		natural.session.dispose();
+	}
+
+	const quietClose = monitorProcess(true, "process.stdout.write('started\\n'); setTimeout(() => process.exit(0), 2000)");
+	try {
+		const result = await quietClose.completion;
+		expect(result).toMatchObject({ cancelled: true, autoClosedOnQuiet: true });
+	} finally {
+		quietClose.session.dispose();
+	}
+});

--- a/tests/overlay-render.test.ts
+++ b/tests/overlay-render.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { InteractiveShellConfig } from "../config.ts";
+import { buildResultNotification } from "../notification-utils.ts";
 
 const config: InteractiveShellConfig = {
 	exitAutoCloseDelay: 10,
@@ -67,6 +68,7 @@ function createExistingSession() {
 
 async function loadOverlay() {
 	vi.resetModules();
+	const spawnedSessions: ReturnType<typeof createExistingSession>[] = [];
 	const sessionManager = {
 		registerActive: vi.fn(),
 		unregisterActive: vi.fn(),
@@ -78,27 +80,38 @@ async function loadOverlay() {
 		visibleWidth: (value: string) => stripAnsi(value).length,
 	}));
 	vi.doMock("../pty-session.ts", () => ({
-		PtyTerminalSession: class MockPtyTerminalSession {},
+		PtyTerminalSession: class MockPtyTerminalSession {
+			constructor() {
+				const session = createExistingSession();
+				spawnedSessions.push(session);
+				return session;
+			}
+		},
 	}));
 	vi.doMock("../session-manager.ts", () => ({
 		sessionManager,
 		generateSessionId: vi.fn(() => "session-1"),
 	}));
 	vi.doMock("../handoff-utils.ts", () => ({
-		captureCompletionOutput: vi.fn(() => undefined),
+		captureCompletionOutput: vi.fn(() => ({ lines: ["final output"], totalLines: 1, truncated: false })),
 		captureTransferOutput: vi.fn(() => undefined),
 		maybeBuildHandoffPreview: vi.fn(() => undefined),
 		maybeWriteHandoffSnapshot: vi.fn(() => undefined),
 	}));
 	vi.doMock("../session-query.ts", () => ({
 		createSessionQueryState: vi.fn(() => ({})),
-		getSessionOutput: vi.fn(() => ({ output: "", truncated: false, totalBytes: 0 })),
+		getSessionOutput: vi.fn((_session, _config, _state, _options, completionOutput) => ({
+			output: completionOutput?.lines.join("\n") ?? "",
+			truncated: false,
+			totalBytes: completionOutput?.lines.join("\n").length ?? 0,
+		})),
 	}));
-	return { ...(await import("../overlay-component.ts")), sessionManager };
+	return { ...(await import("../overlay-component.ts")), sessionManager, spawnedSessions };
 }
 
 describe("InteractiveShellOverlay render focus cues", () => {
 	afterEach(() => {
+		vi.useRealTimers();
 		vi.doUnmock("@earendil-works/pi-tui");
 		vi.doUnmock("../pty-session.ts");
 		vi.doUnmock("../session-manager.ts");
@@ -172,5 +185,61 @@ describe("InteractiveShellOverlay render focus cues", () => {
 		expect(focused).toContain("SHELL FOCUSED");
 		expect(focused).toContain("╔");
 		expect(focused).toContain("╝");
+	});
+
+	it("keeps a quiet dispatch alive unless auto-exit is explicitly enabled", async () => {
+		vi.useFakeTimers();
+		const { InteractiveShellOverlay, spawnedSessions } = await loadOverlay();
+		let result: any;
+		const overlay = new InteractiveShellOverlay(
+			{ terminal: { columns: 120, rows: 40 }, requestRender: vi.fn() } as any,
+			{ fg: (_color: string, text: string) => text, bg: (_color: string, text: string) => text, bold: (text: string) => text } as any,
+			{ command: "pi", mode: "dispatch", sessionId: "default-dispatch", handsFreeQuietThreshold: 10, autoExitGracePeriod: 0 },
+			config,
+			(value) => { result = value; },
+		);
+
+		vi.advanceTimersByTime(10);
+
+		expect(result).toBeUndefined();
+		expect(spawnedSessions[0]?.kill).not.toHaveBeenCalled();
+		overlay.dispose();
+	});
+
+	it.each([
+		["foreground", undefined],
+		["reattach", createExistingSession()],
+	])("reports and retains an explicit quiet close for %s dispatch", async (_path, existingSession) => {
+		vi.useFakeTimers();
+		const { InteractiveShellOverlay, sessionManager, spawnedSessions } = await loadOverlay();
+		let result: any;
+		const overlay = new InteractiveShellOverlay(
+			{ terminal: { columns: 120, rows: 40 }, requestRender: vi.fn() } as any,
+			{ fg: (_color: string, text: string) => text, bg: (_color: string, text: string) => text, bold: (text: string) => text } as any,
+			{
+				command: "pi",
+				existingSession: existingSession as any,
+				mode: "dispatch",
+				sessionId: `${_path}-dispatch`,
+				autoExitOnQuiet: true,
+				handsFreeQuietThreshold: 10,
+				autoExitGracePeriod: 0,
+			},
+			config,
+			(value) => { result = value; },
+		);
+
+		vi.advanceTimersByTime(10);
+
+		const session = existingSession ?? spawnedSessions[0]!;
+		const active = sessionManager.registerActive.mock.calls.at(-1)?.[0];
+		expect(result).toMatchObject({ cancelled: true, autoClosedOnQuiet: true });
+		expect(buildResultNotification(`${_path}-dispatch`, result)).toContain("auto-closed after quiet");
+		expect(active.retainAfterCompletion).toBe(true);
+		expect(active.getStatus()).toBe("auto-closed-on-quiet");
+		expect(active.getOutput(true).output).toBe("final output");
+		expect(session.kill).toHaveBeenCalledTimes(1);
+		expect(session.dispose).not.toHaveBeenCalled();
+		overlay.dispose();
 	});
 });

--- a/tests/session-manager.test.ts
+++ b/tests/session-manager.test.ts
@@ -41,6 +41,30 @@ describe("ShellSessionManager", () => {
 		expect(manager.list()).toHaveLength(0);
 	});
 
+	it("retains completed active output until scheduled cleanup releases it", () => {
+		const manager = new ShellSessionManager();
+		const dispose = vi.fn();
+		manager.registerActive({
+			id: "completed-dispatch",
+			command: "pi \"scan\"",
+			write: vi.fn(),
+			kill: vi.fn(),
+			background: vi.fn(),
+			getOutput: vi.fn() as any,
+			getStatus: vi.fn(() => "auto-closed-on-quiet") as any,
+			getRuntime: vi.fn(() => 0),
+			getResult: vi.fn(() => ({ exitCode: null, cancelled: true, autoClosedOnQuiet: true })),
+			dispose,
+			onComplete: vi.fn(),
+		});
+
+		manager.scheduleActiveCleanup("completed-dispatch", 100);
+		expect(manager.getActive("completed-dispatch")).toBeDefined();
+		vi.advanceTimersByTime(100);
+		expect(dispose).toHaveBeenCalledTimes(1);
+		expect(manager.getActive("completed-dispatch")).toBeUndefined();
+	});
+
 	it("killAll kills active sessions and removes background sessions", () => {
 		const manager = new ShellSessionManager();
 		const backgroundSession = createSession() as any;

--- a/tool-schema.ts
+++ b/tool-schema.ts
@@ -97,7 +97,7 @@ Workflow:
 2. Do other work - no polling needed
 3. When complete, you receive a notification with the session output
 
-Dispatch defaults autoExitOnQuiet to true (opt-out with handsFree.autoExitOnQuiet: false). A quiet TUI auto-closes after the threshold and reports that completion reason separately from a user kill.
+Dispatch waits for process exit by default. Enable handsFree.autoExitOnQuiet only when silence is an explicit completion condition; otherwise a quiet coding agent may still be working.
 You can still query with sessionId if needed, but it's not required.
 
 BACKGROUND DISPATCH (HEADLESS):

--- a/types.ts
+++ b/types.ts
@@ -9,6 +9,8 @@ export interface InteractiveShellResult {
 	backgroundId?: string;
 	cancelled: boolean;
 	timedOut?: boolean;
+	/** The session was intentionally closed after the configured quiet threshold. */
+	autoClosedOnQuiet?: boolean;
 	sessionId?: string;
 	userTookOver?: boolean;
 	/** When user triggers "Transfer" action, this contains the captured output */


### PR DESCRIPTION
## Summary

- wait for process exit by default for headless, foreground, reattached, and foreground-to-background dispatch sessions
- enable quiet auto-close only when `handsFree.autoExitOnQuiet: true` is explicit
- report explicit quiet closure separately from user kill
- retain completed foreground/reattached output for the documented five-minute query window before disposing resources
- update schema, README, skills, changelog, and lifecycle coverage

## Validation

- Vitest: 20 files, 97 tests passed
- TypeScript strict check passed
- real PTY regression proves a quiet process survives past the threshold and exits naturally
- negative control proves explicit quiet auto-close still terminates and reports accurately
- independent review passed

The repository `pnpm` scripts attempted dependency setup and stopped on ignored build scripts, so validation invoked the already-installed underlying Vitest and TypeScript binaries directly. No generated manifests are included.