### PR TITLE
fix: handle session placeholders and force PTY cleanup

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1223,7 +1223,8 @@ export default function interactiveShellExtension(pi: ExtensionAPI) {
 				? { text: input, keys: inputKeys, hex: inputHex, paste: inputPaste }
 				: input;
 			const normalizedSpawn = normalizeSpawnRequest(spawn);
-			const spawnForAction = command && isEmptySpawnPlaceholder(spawn)
+			const hasExistingSessionAction = Boolean(sessionId || attach || listBackground || dismissBackground || monitorEvents || monitorStatus);
+			const spawnForAction = (command || hasExistingSessionAction) && isEmptySpawnPlaceholder(spawn)
 				? undefined
 				: normalizedSpawn;
 

--- a/pty-session.ts
+++ b/pty-session.ts
@@ -159,6 +159,7 @@ export class PtyTerminalSession {
 	private exitHandler: ((exitCode: number, signal?: number) => void) | undefined;
 	private additionalDataListeners: Array<(data: string) => void> = [];
 	private additionalExitListeners: Array<(exitCode: number, signal?: number) => void> = [];
+	private forceKillTimer: ReturnType<typeof setTimeout> | null = null;
 
 	// Trim raw output buffer if it exceeds max size
 	private trimRawOutputIfNeeded(): void {
@@ -256,6 +257,7 @@ export class PtyTerminalSession {
 		});
 
 		this.ptyProcess.onExit(({ exitCode, signal }) => {
+			this.clearForceKillTimer();
 			this._exited = true;
 			this._exitCode = exitCode;
 			this._signal = signal;
@@ -311,6 +313,13 @@ export class PtyTerminalSession {
 		// Copy array to avoid issues if a listener unsubscribes during iteration
 		for (const listener of [...this.additionalExitListeners]) {
 			listener(exitCode, signal);
+		}
+	}
+
+	private clearForceKillTimer(): void {
+		if (this.forceKillTimer) {
+			clearTimeout(this.forceKillTimer);
+			this.forceKillTimer = null;
 		}
 	}
 
@@ -590,30 +599,38 @@ export class PtyTerminalSession {
 
 	kill(signal: string = "SIGTERM"): void {
 		if (this._exited) return;
+		if (signal === "SIGKILL") this.clearForceKillTimer();
 
 		const pid = this.ptyProcess.pid;
 
-		// Try to kill the entire process tree (prevents orphan child processes)
+		// Kill the process group first so descendants receive the signal too.
 		if (process.platform !== "win32" && pid) {
 			try {
-				// Kill process group (negative PID)
 				process.kill(-pid, signal as NodeJS.Signals);
-				return;
 			} catch {
-				// Fall through to direct kill
+				// Fall through to the PTY's direct kill.
 			}
 		}
 
-		// Direct kill as fallback
+		// Always ask the PTY to kill its leader as well. A successful process-group
+		// signal does not guarantee that the PTY leader has exited.
 		try {
 			this.ptyProcess.kill(signal);
 		} catch {
 			// Process may already be dead
 		}
+
+		if (signal !== "SIGKILL" && !this.forceKillTimer) {
+			this.forceKillTimer = setTimeout(() => {
+				this.forceKillTimer = null;
+				if (!this._exited) this.kill("SIGKILL");
+			}, 250);
+			this.forceKillTimer.unref?.();
+		}
 	}
 
 	dispose(): void {
-		this.kill();
+		this.kill("SIGKILL");
 		try {
 			this.ptyProcess.close();
 		} catch {

--- a/tests/input-submit.test.ts
+++ b/tests/input-submit.test.ts
@@ -90,6 +90,7 @@ describe("interactive_shell submit input helper", () => {
 
 		const result = await harness.tool!.execute("call-1", {
 			sessionId: "sess-1",
+			spawn: { agent: "", mode: "fresh", worktree: false, prompt: "" },
 			input: "/run manual-slash-check summarize src/alpha.ts in 2 short bullets",
 			submit: true,
 		}, undefined, undefined, harness.ctx as any);

--- a/tests/pty-session.test.ts
+++ b/tests/pty-session.test.ts
@@ -1,0 +1,42 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { PtyTerminalSession } from "../pty-session.ts";
+
+const sessions: PtyTerminalSession[] = [];
+
+function processExists(pid: number): boolean {
+	try {
+		process.kill(pid, 0);
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+async function waitForProcessExit(pid: number, timeoutMs = 1000): Promise<void> {
+	const deadline = Date.now() + timeoutMs;
+	while (processExists(pid) && Date.now() < deadline) {
+		await new Promise((resolve) => setTimeout(resolve, 20));
+	}
+}
+
+afterEach(() => {
+	for (const session of sessions.splice(0)) {
+		if (!session.exited) session.kill("SIGKILL");
+		session.dispose();
+	}
+});
+
+describe("PtyTerminalSession cleanup", () => {
+	it("kill forcefully terminates an interactive shell", async () => {
+		const session = new PtyTerminalSession({ command: "bash -i" });
+		sessions.push(session);
+		const pid = session.pid;
+		await new Promise((resolve) => setTimeout(resolve, 100));
+		expect(processExists(pid)).toBe(true);
+
+		session.kill();
+		await waitForProcessExit(pid);
+
+		expect(processExists(pid)).toBe(false);
+	});
+});


### PR DESCRIPTION
## Summary

- Ignore schema-generated empty `spawn` placeholders when operating on an existing session.
- Make PTY termination reliable when an interactive shell does not exit after `SIGTERM`.
- Add regression coverage for both behaviors.

## Root cause

Existing-session calls could receive a fully defaulted empty `spawn` object from schema validation. The plugin treated it as a new-session request and rejected the call with:

```text
spawn is only valid when starting a new session.
```

PTY cleanup only sent `SIGTERM` and could return while an interactive shell was still running. This could leave the session active and cause `kill: true` to hang during cleanup.

## Changes

- Existing-session actions now discard only the complete empty `spawn` placeholder.
- Valid `spawn` requests and new-session behavior are unchanged.
- PTY cleanup terminates the process group and PTY leader.
- Unresponsive processes are escalated to `SIGKILL` after 250ms.
- `dispose()` performs forceful cleanup.
- Added tests for `sessionId + empty spawn` and interactive `bash -i` termination.

## Validation

- `npm test`: 20 test files, 97 tests passed
- `npm run typecheck`: passed
- `git diff --check`: passed
- Confirmed no residual `bash -i` or `zigpty` processes after the cleanup test