### PR TITLE
fix: stabilize interactive session lifecycle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to the `pi-interactive-shell` extension will be documented i
 
 ### Fixed
 - Expose dispatch quiet auto-close as `completionReason: "auto-close-quiet"` and mark it as non-terminal in notifications.
+- Fix existing-session calls that include schema-generated empty spawn placeholders, and force PTY cleanup to SIGKILL when SIGTERM does not exit (#44, by [@ZacharyQin](https://github.com/ZacharyQin)).
 
 ### Changed
 - Document a provider-agnostic watch-until-terminal monitor recipe for external gates.

--- a/index.ts
+++ b/index.ts
@@ -1223,7 +1223,8 @@ export default function interactiveShellExtension(pi: ExtensionAPI) {
 				? { text: input, keys: inputKeys, hex: inputHex, paste: inputPaste }
 				: input;
 			const normalizedSpawn = normalizeSpawnRequest(spawn);
-			const spawnForAction = command && isEmptySpawnPlaceholder(spawn)
+			const hasExistingSessionAction = Boolean(sessionId || attach || listBackground || dismissBackground || monitorEvents || monitorStatus);
+			const spawnForAction = (command || hasExistingSessionAction) && isEmptySpawnPlaceholder(spawn)
 				? undefined
 				: normalizedSpawn;
 

--- a/pty-session.ts
+++ b/pty-session.ts
@@ -159,6 +159,7 @@ export class PtyTerminalSession {
 	private exitHandler: ((exitCode: number, signal?: number) => void) | undefined;
 	private additionalDataListeners: Array<(data: string) => void> = [];
 	private additionalExitListeners: Array<(exitCode: number, signal?: number) => void> = [];
+	private forceKillTimer: ReturnType<typeof setTimeout> | null = null;
 
 	// Trim raw output buffer if it exceeds max size
 	private trimRawOutputIfNeeded(): void {
@@ -256,6 +257,7 @@ export class PtyTerminalSession {
 		});
 
 		this.ptyProcess.onExit(({ exitCode, signal }) => {
+			this.clearForceKillTimer();
 			this._exited = true;
 			this._exitCode = exitCode;
 			this._signal = signal;
@@ -311,6 +313,13 @@ export class PtyTerminalSession {
 		// Copy array to avoid issues if a listener unsubscribes during iteration
 		for (const listener of [...this.additionalExitListeners]) {
 			listener(exitCode, signal);
+		}
+	}
+
+	private clearForceKillTimer(): void {
+		if (this.forceKillTimer) {
+			clearTimeout(this.forceKillTimer);
+			this.forceKillTimer = null;
 		}
 	}
 
@@ -590,30 +599,38 @@ export class PtyTerminalSession {
 
 	kill(signal: string = "SIGTERM"): void {
 		if (this._exited) return;
+		if (signal === "SIGKILL") this.clearForceKillTimer();
 
 		const pid = this.ptyProcess.pid;
 
-		// Try to kill the entire process tree (prevents orphan child processes)
+		// Kill the process group first so descendants receive the signal too.
 		if (process.platform !== "win32" && pid) {
 			try {
-				// Kill process group (negative PID)
 				process.kill(-pid, signal as NodeJS.Signals);
-				return;
 			} catch {
-				// Fall through to direct kill
+				// Fall through to the PTY's direct kill.
 			}
 		}
 
-		// Direct kill as fallback
+		// Always ask the PTY to kill its leader as well. A successful process-group
+		// signal does not guarantee that the PTY leader has exited.
 		try {
 			this.ptyProcess.kill(signal);
 		} catch {
 			// Process may already be dead
 		}
+
+		if (signal !== "SIGKILL" && !this.forceKillTimer) {
+			this.forceKillTimer = setTimeout(() => {
+				this.forceKillTimer = null;
+				if (!this._exited) this.kill("SIGKILL");
+			}, 250);
+			this.forceKillTimer.unref?.();
+		}
 	}
 
 	dispose(): void {
-		this.kill();
+		this.kill("SIGKILL");
 		try {
 			this.ptyProcess.close();
 		} catch {

--- a/tests/input-submit.test.ts
+++ b/tests/input-submit.test.ts
@@ -90,6 +90,7 @@ describe("interactive_shell submit input helper", () => {
 
 		const result = await harness.tool!.execute("call-1", {
 			sessionId: "sess-1",
+			spawn: { agent: "", mode: "fresh", worktree: false, prompt: "" },
 			input: "/run manual-slash-check summarize src/alpha.ts in 2 short bullets",
 			submit: true,
 		}, undefined, undefined, harness.ctx as any);

--- a/tests/pty-session.test.ts
+++ b/tests/pty-session.test.ts
@@ -1,0 +1,42 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { PtyTerminalSession } from "../pty-session.ts";
+
+const sessions: PtyTerminalSession[] = [];
+
+function processExists(pid: number): boolean {
+	try {
+		process.kill(pid, 0);
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+async function waitForProcessExit(pid: number, timeoutMs = 1000): Promise<void> {
+	const deadline = Date.now() + timeoutMs;
+	while (processExists(pid) && Date.now() < deadline) {
+		await new Promise((resolve) => setTimeout(resolve, 20));
+	}
+}
+
+afterEach(() => {
+	for (const session of sessions.splice(0)) {
+		if (!session.exited) session.kill("SIGKILL");
+		session.dispose();
+	}
+});
+
+describe("PtyTerminalSession cleanup", () => {
+	it("kill forcefully terminates an interactive shell", async () => {
+		const session = new PtyTerminalSession({ command: "bash -i" });
+		sessions.push(session);
+		const pid = session.pid;
+		await new Promise((resolve) => setTimeout(resolve, 100));
+		expect(processExists(pid)).toBe(true);
+
+		session.kill();
+		await waitForProcessExit(pid);
+
+		expect(processExists(pid)).toBe(false);
+	});
+});


### PR DESCRIPTION
## Summary

- Re-publish PR #44 from @ZacharyQin on a maintainer branch because the original head is in an external fork.
- Preserve the original fix for schema-generated empty `spawn` placeholders on existing-session actions.
- Preserve the PTY cleanup escalation from SIGTERM to SIGKILL when an interactive shell does not exit.
- Add the required changelog credit for #44.

## Validation

- Exact-head source review: no issues found.
- `npm exec -- vitest run tests/input-submit.test.ts tests/pty-session.test.ts --silent` passed on the original exact head.
- `npm run typecheck` passed on the original exact head.
- `npm test -- --silent` passed on the original exact head.
- `git diff --check HEAD^..HEAD` passed for the changelog credit commit.

Supersedes #44 after this replacement lands. Thanks to [@ZacharyQin](https://github.com/ZacharyQin) for the implementation.
