### PR TITLE
fix: tolerate stale background widget cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to the `pi-interactive-shell` extension will be documented i
 ## [Unreleased]
 
 ### Fixed
+- Prevent stale background-widget cleanup from reusing an expired session context after `/clear` or session replacement (#42, reported by [@luluxiang06](https://github.com/luluxiang06)).
 - Expose dispatch quiet auto-close as `completionReason: "auto-close-quiet"` and mark it as non-terminal in notifications.
 
 ### Changed

--- a/background-widget.ts
+++ b/background-widget.ts
@@ -84,6 +84,10 @@ export function setupBackgroundWidget(
 			clearInterval(durationTimer);
 			durationTimer = null;
 		}
-		ctx.ui.setWidget("bg-sessions", undefined);
+		try {
+			ctx.ui.setWidget("bg-sessions", undefined);
+		} catch {
+			// The session ctx can be stale during replacement. Local cleanup is already done.
+		}
 	};
 }

--- a/runtime-coordinator.ts
+++ b/runtime-coordinator.ts
@@ -207,12 +207,14 @@ export class InteractiveShellCoordinator {
 	}
 
 	replaceBackgroundWidgetCleanup(cleanup: (() => void) | null): void {
-		this.bgWidgetCleanup?.();
+		const previous = this.bgWidgetCleanup;
 		this.bgWidgetCleanup = cleanup;
+		previous?.();
 	}
 
 	clearBackgroundWidget(): void {
-		this.bgWidgetCleanup?.();
+		const previous = this.bgWidgetCleanup;
 		this.bgWidgetCleanup = null;
+		previous?.();
 	}
 }

--- a/tests/background-widget.test.ts
+++ b/tests/background-widget.test.ts
@@ -1,0 +1,41 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { setupBackgroundWidget } from "../background-widget.ts";
+
+describe("setupBackgroundWidget cleanup", () => {
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	it("releases local resources before tolerating stale ctx widget removal", () => {
+		vi.useFakeTimers();
+		const events: string[] = [];
+		const unsubscribe = vi.fn();
+		const ctx = {
+			hasUI: true,
+			ui: {
+				setWidget: vi.fn((name: string, value: unknown) => {
+					expect(name).toBe("bg-sessions");
+					events.push(value === undefined ? "set:cleanup" : "set:register");
+					if (value === undefined) throw new Error("stale ctx");
+				}),
+			},
+		};
+		const sessionManager = {
+			onChange: vi.fn(() => () => {
+				events.push("unsubscribe");
+				unsubscribe();
+			}),
+			list: vi.fn(() => [{ session: { exited: false } }]),
+		};
+
+		const cleanup = setupBackgroundWidget(ctx, sessionManager as any);
+		expect(cleanup).toBeTypeOf("function");
+		expect(vi.getTimerCount()).toBe(1);
+
+		expect(() => cleanup?.()).not.toThrow();
+		expect(events).toEqual(["set:register", "unsubscribe", "set:cleanup"]);
+		expect(unsubscribe).toHaveBeenCalledOnce();
+		expect(vi.getTimerCount()).toBe(0);
+		expect(ctx.ui.setWidget).toHaveBeenCalledTimes(2);
+	});
+});

--- a/tests/runtime-coordinator.test.ts
+++ b/tests/runtime-coordinator.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { InteractiveShellCoordinator } from "../runtime-coordinator.ts";
 
 describe("InteractiveShellCoordinator monitor state", () => {
@@ -54,5 +54,40 @@ describe("InteractiveShellCoordinator monitor state", () => {
 		coordinator.clearMonitorEvents("calm-reef");
 		expect(coordinator.getMonitorSessionState("calm-reef")).toBeUndefined();
 		expect(coordinator.getMonitorEvents("calm-reef").events).toHaveLength(0);
+	});
+});
+
+describe("InteractiveShellCoordinator background widget cleanup", () => {
+	it("stores the replacement cleanup before running the previous cleanup", () => {
+		const coordinator = new InteractiveShellCoordinator();
+		const calls: string[] = [];
+
+		coordinator.replaceBackgroundWidgetCleanup(() => {
+			calls.push("stale");
+			throw new Error("stale ctx");
+		});
+
+		expect(() => coordinator.replaceBackgroundWidgetCleanup(() => calls.push("fresh"))).toThrow("stale ctx");
+		expect(calls).toEqual(["stale"]);
+
+		expect(() => coordinator.replaceBackgroundWidgetCleanup(null)).not.toThrow();
+		expect(calls).toEqual(["stale", "fresh"]);
+	});
+
+	it("clears the stored cleanup before running the previous cleanup", () => {
+		const coordinator = new InteractiveShellCoordinator();
+		const stale = vi.fn(() => {
+			throw new Error("stale ctx");
+		});
+		const fresh = vi.fn();
+
+		coordinator.replaceBackgroundWidgetCleanup(stale);
+		expect(() => coordinator.clearBackgroundWidget()).toThrow("stale ctx");
+		expect(stale).toHaveBeenCalledTimes(1);
+
+		coordinator.replaceBackgroundWidgetCleanup(fresh);
+		coordinator.clearBackgroundWidget();
+		expect(stale).toHaveBeenCalledTimes(1);
+		expect(fresh).toHaveBeenCalledTimes(1);
 	});
 });


### PR DESCRIPTION
## Summary

- Fix stale background-widget cleanup after `/clear` or session replacement.
- Store or clear coordinator cleanup state before invoking the previous cleanup.
- Tolerate only the cleanup-time stale `ctx.ui.setWidget("bg-sessions", undefined)` boundary after local resources are released.
- Add focused regressions for coordinator ordering and widget cleanup.

Fixes #42.

## Validation

- `npx vitest run tests/runtime-coordinator.test.ts tests/background-widget.test.ts --silent`
- `npm run typecheck`
- `git diff --check origin/main...HEAD`
- Fresh read-only review: no issues found.

Thanks to [@luluxiang06](https://github.com/luluxiang06) for the report.
