### PR TITLE
fix: retain dispatch completion output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to the `pi-interactive-shell` extension will be documented i
 ## [Unreleased]
 
 ### Fixed
+- Keep completed foreground or reattached dispatch output queryable for the documented five-minute cleanup window. Thanks to [@gwelinder](https://github.com/gwelinder) for #43.
 - Prevent stale background-widget cleanup from reusing an expired session context after `/clear` or session replacement (#42, reported by [@luluxiang06](https://github.com/luluxiang06)).
 - Expose dispatch quiet auto-close as `completionReason: "auto-close-quiet"` and mark it as non-terminal in notifications.
 - Fix existing-session calls that include schema-generated empty spawn placeholders, and force PTY cleanup to SIGKILL when SIGTERM does not exit (#44, by [@ZacharyQin](https://github.com/ZacharyQin)).

--- a/index.ts
+++ b/index.ts
@@ -1361,6 +1361,7 @@ export default function interactiveShellExtension(pi: ExtensionAPI) {
 					const status = session.getStatus();
 					const runtime = session.getRuntime();
 					session.kill();
+					session.dispose?.();
 					sessionManager.unregisterActive(sessionId, true);
 
 					const truncatedNote = truncated ? ` (${totalBytes} bytes total, truncated)` : "";
@@ -1441,7 +1442,9 @@ export default function interactiveShellExtension(pi: ExtensionAPI) {
 						const truncatedNote = truncated ? ` (${totalBytes} bytes total, truncated)` : "";
 						const hasOutput = output.length > 0;
 						const hasMoreNote = hasMore === true ? " (more available)" : "";
-						sessionManager.unregisterActive(sessionId, !result.backgrounded);
+						if (!session.retainAfterCompletion) {
+							sessionManager.unregisterActive(sessionId, !result.backgrounded);
+						}
 						return {
 							content: [{ type: "text", text: `Session ${sessionId} ${status} after ${formatDurationMs(runtime)}${hasOutput ? `\n\nOutput${truncatedNote}${hasMoreNote}:\n${output}` : ""}` }],
 							details: { sessionId, status, runtime, output, outputTruncated: truncated, outputTotalBytes: totalBytes, outputTotalLines: totalLines, hasMore, exitCode: result.exitCode, signal: result.signal, backgroundId: result.backgroundId },
@@ -1470,7 +1473,9 @@ export default function interactiveShellExtension(pi: ExtensionAPI) {
 							const hasOutput = output.length > 0;
 							const hasMoreNote = hasMore === true ? " (more available)" : "";
 							if (earlyResult) {
-								sessionManager.unregisterActive(sessionId, !earlyResult.backgrounded);
+								if (!earlySession.retainAfterCompletion) {
+									sessionManager.unregisterActive(sessionId, !earlyResult.backgrounded);
+								}
 								return {
 									content: [{ type: "text", text: `Session ${sessionId} ${earlyStatus} after ${formatDurationMs(earlyRuntime)}${hasOutput ? `\n\nOutput${truncatedNote}${hasMoreNote}:\n${output}` : ""}` }],
 									details: { sessionId, status: earlyStatus, runtime: earlyRuntime, output, outputTruncated: truncated, outputTotalBytes: totalBytes, outputTotalLines: totalLines, hasMore, exitCode: earlyResult.exitCode, signal: earlyResult.signal, backgroundId: earlyResult.backgroundId },
@@ -1490,7 +1495,9 @@ export default function interactiveShellExtension(pi: ExtensionAPI) {
 						const freshRuntime = session.getRuntime();
 						const freshResult = session.getResult();
 						if (freshResult) {
-							sessionManager.unregisterActive(sessionId, !freshResult.backgrounded);
+							if (!session.retainAfterCompletion) {
+								sessionManager.unregisterActive(sessionId, !freshResult.backgrounded);
+							}
 							return {
 								content: [{ type: "text", text: `Session ${sessionId} ${freshStatus} after ${formatDurationMs(freshRuntime)}${hasOutput ? `\n\nOutput${truncatedNote}${hasMoreNote}:\n${freshOutput.output}` : ""}` }],
 								details: { sessionId, status: freshStatus, runtime: freshRuntime, output: freshOutput.output, outputTruncated: freshOutput.truncated, outputTotalBytes: freshOutput.totalBytes, outputTotalLines: freshOutput.totalLines, hasMore: freshOutput.hasMore, exitCode: freshResult.exitCode, signal: freshResult.signal, backgroundId: freshResult.backgroundId },
@@ -1997,7 +2004,7 @@ function setupDispatchCompletion(
 				timedOut: result.timedOut,
 				cancelled: result.cancelled,
 			});
-			sessionManager.unregisterActive(id, true);
+			sessionManager.scheduleCleanup(id, 5 * 60 * 1000);
 			coordinator.disposeMonitor(id);
 			return;
 		}

--- a/overlay-component.ts
+++ b/overlay-component.ts
@@ -41,6 +41,7 @@ export class InteractiveShellOverlay implements Component, Focusable {
 	private startTime: number;
 	private sessionId: string | null = null;
 	private sessionUnregistered = false;
+	private sessionDisposed = false;
 	// Timeout
 	private timeoutTimer: ReturnType<typeof setTimeout> | null = null;
 	// Prevent double done() calls
@@ -164,6 +165,8 @@ export class InteractiveShellOverlay implements Component, Focusable {
 				getStatus: () => this.getSessionStatus(),
 				getRuntime: () => this.getRuntime(),
 				getResult: () => this.getCompletionResult(),
+				dispose: () => this.disposeTerminalSession(),
+				retainAfterCompletion: this.options.mode === "dispatch",
 				setUpdateInterval: (intervalMs) => this.setUpdateInterval(intervalMs),
 				setQuietThreshold: (thresholdMs) => this.setQuietThreshold(thresholdMs),
 				onComplete: (callback) => this.registerCompleteCallback(callback),
@@ -449,6 +452,16 @@ export class InteractiveShellOverlay implements Component, Focusable {
 		}
 	}
 
+	private disposeTerminalSession(): void {
+		if (this.sessionDisposed) return;
+		this.session.dispose();
+		this.sessionDisposed = true;
+	}
+
+	private shouldRetainTerminalAfterCompletion(): boolean {
+		return this.options.mode === "dispatch" && this.options.streamingMode !== true;
+	}
+
 	private emitHandsFreeUpdate(): void {
 		if (!this.options.onHandsFreeUpdate || !this.sessionId) return;
 
@@ -554,6 +567,8 @@ export class InteractiveShellOverlay implements Component, Focusable {
 				getStatus: () => this.getSessionStatus(),
 				getRuntime: () => this.getRuntime(),
 				getResult: () => this.getCompletionResult(),
+				dispose: () => this.disposeTerminalSession(),
+				retainAfterCompletion: this.options.mode === "dispatch",
 				setUpdateInterval: (intervalMs) => this.setUpdateInterval(intervalMs),
 				setQuietThreshold: (thresholdMs) => this.setQuietThreshold(thresholdMs),
 				onComplete: (callback) => this.registerCompleteCallback(callback),
@@ -622,7 +637,6 @@ export class InteractiveShellOverlay implements Component, Focusable {
 		const handoffPreview = this.maybeBuildHandoffPreview("exit");
 		const handoff = this.maybeWriteHandoffSnapshot("exit");
 		const completionOutput = this.captureCompletionOutput();
-		this.session.dispose();
 		const result: InteractiveShellResult = {
 			exitCode: this.session.exitCode,
 			signal: this.session.signal,
@@ -636,6 +650,9 @@ export class InteractiveShellOverlay implements Component, Focusable {
 		};
 		this.completionResult = result;
 		this.triggerCompleteCallbacks();
+		if (!this.shouldRetainTerminalAfterCompletion()) {
+			this.disposeTerminalSession();
+		}
 
 		// In streaming mode (blocking tool call), unregister now since the agent
 		// gets the result via tool return. Otherwise keep registered for queries.
@@ -696,7 +713,6 @@ export class InteractiveShellOverlay implements Component, Focusable {
 		const handoff = this.maybeWriteHandoffSnapshot("kill");
 		const completionOutput = this.captureCompletionOutput();
 		this.session.kill();
-		this.session.dispose();
 		const result: InteractiveShellResult = {
 			exitCode: null,
 			completionReason,
@@ -710,6 +726,9 @@ export class InteractiveShellOverlay implements Component, Focusable {
 		};
 		this.completionResult = result;
 		this.triggerCompleteCallbacks();
+		if (!this.shouldRetainTerminalAfterCompletion()) {
+			this.disposeTerminalSession();
+		}
 
 		// In streaming mode (blocking tool call), unregister now since the agent
 		// gets the result via tool return. Otherwise keep registered for queries.
@@ -734,7 +753,7 @@ export class InteractiveShellOverlay implements Component, Focusable {
 		const handoff = this.maybeWriteHandoffSnapshot("transfer");
 
 		this.session.kill();
-		this.session.dispose();
+		this.disposeTerminalSession();
 		const result: InteractiveShellResult = {
 			exitCode: this.session.exitCode,
 			signal: this.session.signal,
@@ -789,7 +808,6 @@ export class InteractiveShellOverlay implements Component, Focusable {
 		const handoff = this.maybeWriteHandoffSnapshot("timeout");
 		const completionOutput = this.captureCompletionOutput();
 		this.session.kill();
-		this.session.dispose();
 		const result: InteractiveShellResult = {
 			exitCode: null,
 			backgrounded: false,
@@ -803,6 +821,9 @@ export class InteractiveShellOverlay implements Component, Focusable {
 		};
 		this.completionResult = result;
 		this.triggerCompleteCallbacks();
+		if (!this.shouldRetainTerminalAfterCompletion()) {
+			this.disposeTerminalSession();
+		}
 
 		// In streaming mode (blocking tool call), unregister now since the agent
 		// gets the result via tool return. Otherwise keep registered for queries.
@@ -1087,10 +1108,11 @@ export class InteractiveShellOverlay implements Component, Focusable {
 		// If session hasn't completed yet, kill it to prevent orphaned processes
 		if (!this.completionResult) {
 			this.session.kill();
-			this.session.dispose();
+			this.disposeTerminalSession();
 			this.unregisterActiveSession(true);
 		} else if (this.options.streamingMode) {
 			// Streaming mode already delivered result via tool return, safe to clean up
+			this.disposeTerminalSession();
 			this.unregisterActiveSession(true);
 		}
 		// Non-blocking mode with completion: keep registered so agent can query

--- a/session-manager.ts
+++ b/session-manager.ts
@@ -52,6 +52,8 @@ export interface ActiveSession {
 	getStatus: () => ActiveSessionStatus;
 	getRuntime: () => number;
 	getResult: () => ActiveSessionResult | undefined;
+	dispose?: () => void;
+	retainAfterCompletion?: boolean;
 	setUpdateInterval?: (intervalMs: number) => void;
 	setQuietThreshold?: (thresholdMs: number) => void;
 	onComplete: (callback: () => void) => void;
@@ -155,10 +157,20 @@ export class ShellSessionManager {
 	}
 
 	registerActive(session: ActiveSession): void {
+		const cleanupTimer = this.cleanupTimers.get(session.id);
+		if (cleanupTimer) {
+			clearTimeout(cleanupTimer);
+			this.cleanupTimers.delete(session.id);
+		}
 		this.activeSessions.set(session.id, session);
 	}
 
 	unregisterActive(id: string, releaseId = false): void {
+		const cleanupTimer = this.cleanupTimers.get(id);
+		if (cleanupTimer) {
+			clearTimeout(cleanupTimer);
+			this.cleanupTimers.delete(id);
+		}
 		this.activeSessions.delete(id);
 		// Only release the ID if explicitly requested (when session fully terminates)
 		// This prevents ID reuse while session is still running after takeover
@@ -294,6 +306,12 @@ export class ShellSessionManager {
 		if (this.cleanupTimers.has(id)) return;
 		const timer = setTimeout(() => {
 			this.cleanupTimers.delete(id);
+			const activeSession = this.activeSessions.get(id);
+			if (activeSession) {
+				activeSession.dispose?.();
+				this.unregisterActive(id, true);
+				return;
+			}
 			this.remove(id);
 		}, delayMs);
 		this.cleanupTimers.set(id, timer);

--- a/tests/overlay-render.test.ts
+++ b/tests/overlay-render.test.ts
@@ -63,6 +63,9 @@ function createExistingSession() {
 		kill: vi.fn(),
 		dispose: vi.fn(),
 		getTailLines: vi.fn(() => ({ lines: [], totalLinesInBuffer: 0, truncatedByChars: false })),
+		emitExit() {
+			handlers.onExit?.();
+		},
 	};
 }
 
@@ -86,20 +89,26 @@ async function loadOverlay() {
 		generateSessionId: vi.fn(() => "session-1"),
 	}));
 	vi.doMock("../handoff-utils.ts", () => ({
-		captureCompletionOutput: vi.fn(() => undefined),
+		captureCompletionOutput: vi.fn(() => ({ lines: ["final output"], totalLines: 1, truncated: false })),
 		captureTransferOutput: vi.fn(() => undefined),
 		maybeBuildHandoffPreview: vi.fn(() => undefined),
 		maybeWriteHandoffSnapshot: vi.fn(() => undefined),
 	}));
 	vi.doMock("../session-query.ts", () => ({
 		createSessionQueryState: vi.fn(() => ({})),
-		getSessionOutput: vi.fn(() => ({ output: "", truncated: false, totalBytes: 0 })),
+		getSessionOutput: vi.fn((_session, _config, _state, _options, completionOutput) => ({
+			output: completionOutput?.lines.join("\n") ?? "",
+			truncated: completionOutput?.truncated ?? false,
+			totalBytes: completionOutput?.lines.join("\n").length ?? 0,
+			totalLines: completionOutput?.totalLines,
+		})),
 	}));
 	return { ...(await import("../overlay-component.ts")), sessionManager };
 }
 
 describe("InteractiveShellOverlay render focus cues", () => {
 	afterEach(() => {
+		vi.useRealTimers();
 		vi.doUnmock("@earendil-works/pi-tui");
 		vi.doUnmock("../pty-session.ts");
 		vi.doUnmock("../session-manager.ts");
@@ -142,6 +151,80 @@ describe("InteractiveShellOverlay render focus cues", () => {
 			expect.objectContaining({ id: "control-1" }),
 		);
 		expect(result).toMatchObject({ backgrounded: true, backgroundId: "bg-1", sessionId: "control-1" });
+	});
+
+	it("keeps completed dispatch output queryable until cleanup", async () => {
+		const { InteractiveShellOverlay, sessionManager } = await loadOverlay();
+		const session = createExistingSession();
+		let result: any;
+		new InteractiveShellOverlay(
+			{ terminal: { columns: 120, rows: 40 }, requestRender: vi.fn() } as any,
+			{
+				fg: (_color: string, text: string) => text,
+				bg: (_color: string, text: string) => text,
+				bold: (text: string) => text,
+			} as any,
+			{
+				command: "pi",
+				existingSession: session as any,
+				mode: "dispatch",
+				sessionId: "dispatch-1",
+			},
+			config,
+			(value) => { result = value; },
+		);
+
+		session.emitExit();
+
+		const activeSession = sessionManager.registerActive.mock.calls[0][0];
+		expect(result).toMatchObject({ backgrounded: false, sessionId: "dispatch-1" });
+		expect(activeSession.getResult()).toMatchObject({ sessionId: "dispatch-1" });
+		expect(activeSession.getOutput({ skipRateLimit: true })).toMatchObject({ output: "final output", totalLines: 1 });
+		expect(sessionManager.unregisterActive).not.toHaveBeenCalled();
+		expect(session.dispose).not.toHaveBeenCalled();
+	});
+
+	it("disposes non-dispatch active completions immediately", async () => {
+		vi.useFakeTimers();
+		const { InteractiveShellOverlay } = await loadOverlay();
+		const tui = { terminal: { columns: 120, rows: 40 }, requestRender: vi.fn() } as any;
+		const theme = {
+			fg: (_color: string, text: string) => text,
+			bg: (_color: string, text: string) => text,
+			bold: (text: string) => text,
+		} as any;
+
+		const exitSession = createExistingSession();
+		new InteractiveShellOverlay(tui, theme, {
+			command: "pi",
+			existingSession: exitSession as any,
+			mode: "interactive",
+			sessionId: "exit-1",
+		}, config, () => {});
+		exitSession.emitExit();
+		vi.advanceTimersByTime(config.exitAutoCloseDelay * 1000);
+		expect(exitSession.dispose).toHaveBeenCalledTimes(1);
+
+		const killSession = createExistingSession();
+		const killOverlay = new InteractiveShellOverlay(tui, theme, {
+			command: "pi",
+			existingSession: killSession as any,
+			mode: "hands-free",
+			sessionId: "kill-1",
+		}, config, () => {});
+		killOverlay.killSession();
+		expect(killSession.dispose).toHaveBeenCalledTimes(1);
+
+		const timeoutSession = createExistingSession();
+		new InteractiveShellOverlay(tui, theme, {
+			command: "pi",
+			existingSession: timeoutSession as any,
+			mode: "hands-free",
+			sessionId: "timeout-1",
+			timeout: 100,
+		}, config, () => {});
+		vi.advanceTimersByTime(100);
+		expect(timeoutSession.dispose).toHaveBeenCalledTimes(1);
 	});
 
 	it("shows distinct badges and border styles for focused and unfocused states", async () => {

--- a/tests/session-manager.test.ts
+++ b/tests/session-manager.test.ts
@@ -41,6 +41,87 @@ describe("ShellSessionManager", () => {
 		expect(manager.list()).toHaveLength(0);
 	});
 
+	it("disposes retained active sessions on scheduled cleanup", () => {
+		const manager = new ShellSessionManager();
+		const dispose = vi.fn();
+
+		manager.registerActive({
+			id: "active-1",
+			command: "pi \"active\"",
+			write: vi.fn(),
+			kill: vi.fn(),
+			background: vi.fn(),
+			getOutput: vi.fn() as any,
+			getStatus: vi.fn() as any,
+			getRuntime: vi.fn() as any,
+			getResult: vi.fn() as any,
+			dispose,
+			onComplete: vi.fn(),
+		});
+		manager.scheduleCleanup("active-1", 5 * 60 * 1000);
+
+		vi.advanceTimersByTime(5 * 60 * 1000);
+
+		expect(dispose).toHaveBeenCalledTimes(1);
+		expect(manager.getActive("active-1")).toBeUndefined();
+	});
+
+	it("cancels stale active cleanup on unregister or replacement", () => {
+		const manager = new ShellSessionManager();
+		const staleDispose = vi.fn();
+		const nextDispose = vi.fn();
+
+		manager.registerActive({
+			id: "active-1",
+			command: "pi \"active\"",
+			write: vi.fn(),
+			kill: vi.fn(),
+			background: vi.fn(),
+			getOutput: vi.fn() as any,
+			getStatus: vi.fn() as any,
+			getRuntime: vi.fn() as any,
+			getResult: vi.fn() as any,
+			dispose: staleDispose,
+			onComplete: vi.fn(),
+		});
+		manager.scheduleCleanup("active-1", 1000);
+		manager.unregisterActive("active-1");
+		vi.advanceTimersByTime(1000);
+		expect(staleDispose).not.toHaveBeenCalled();
+
+		manager.registerActive({
+			id: "active-1",
+			command: "pi \"active\"",
+			write: vi.fn(),
+			kill: vi.fn(),
+			background: vi.fn(),
+			getOutput: vi.fn() as any,
+			getStatus: vi.fn() as any,
+			getRuntime: vi.fn() as any,
+			getResult: vi.fn() as any,
+			dispose: staleDispose,
+			onComplete: vi.fn(),
+		});
+		manager.scheduleCleanup("active-1", 1000);
+		manager.registerActive({
+			id: "active-1",
+			command: "pi \"next\"",
+			write: vi.fn(),
+			kill: vi.fn(),
+			background: vi.fn(),
+			getOutput: vi.fn() as any,
+			getStatus: vi.fn() as any,
+			getRuntime: vi.fn() as any,
+			getResult: vi.fn() as any,
+			dispose: nextDispose,
+			onComplete: vi.fn(),
+		});
+		vi.advanceTimersByTime(1000);
+		expect(staleDispose).not.toHaveBeenCalled();
+		expect(nextDispose).not.toHaveBeenCalled();
+		expect(manager.getActive("active-1")).toBeDefined();
+	});
+
 	it("killAll kills active sessions and removes background sessions", () => {
 		const manager = new ShellSessionManager();
 		const backgroundSession = createSession() as any;

--- a/tests/spawn-command.test.ts
+++ b/tests/spawn-command.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-type OverlayOptionsCapture = { command: string; reason?: string; cwd?: string; mode?: string; sessionId?: string } | null;
+type OverlayOptionsCapture = { command: string; reason?: string; cwd?: string; mode?: string; sessionId?: string; autoExitOnQuiet?: boolean } | null;
 
 type SpawnConfigOverrides = {
 	focusShortcut?: string;
@@ -78,8 +78,8 @@ async function setupExtensionHarness(configOverrides: SpawnConfigOverrides = {})
 	});
 	vi.doMock("../overlay-component.ts", () => ({
 		InteractiveShellOverlay: class MockInteractiveShellOverlay {
-			constructor(_tui: unknown, _theme: unknown, options: { command: string; reason?: string; cwd?: string; mode?: string; sessionId?: string }) {
-				lastOverlayOptions = { command: options.command, reason: options.reason, cwd: options.cwd, mode: options.mode, sessionId: options.sessionId };
+			constructor(_tui: unknown, _theme: unknown, options: { command: string; reason?: string; cwd?: string; mode?: string; sessionId?: string; autoExitOnQuiet?: boolean }) {
+				lastOverlayOptions = { command: options.command, reason: options.reason, cwd: options.cwd, mode: options.mode, sessionId: options.sessionId, autoExitOnQuiet: options.autoExitOnQuiet };
 			}
 		},
 	}));
@@ -343,6 +343,28 @@ describe("/spawn command, shortcut, and tool spawn", () => {
 		expect(result.details.mode).toBe("interactive");
 		expect(result.details.sessionId).toBe(harness.getLastOverlayOptions()?.sessionId);
 		expect(harness.getLastOverlayOptions()).toMatchObject({ command: "pi", mode: "interactive" });
+	});
+
+	it("keeps dispatch quiet auto-close on by default and hands-free off", async () => {
+		const dispatchHarness = await setupExtensionHarness();
+		const dispatchTool = dispatchHarness.getTool();
+		expect(dispatchTool).toBeTruthy();
+
+		await dispatchTool!.execute("call-1", {
+			command: "pi",
+			mode: "dispatch",
+		}, undefined, undefined, dispatchHarness.ctx as any);
+		expect(dispatchHarness.getLastOverlayOptions()).toMatchObject({ mode: "dispatch", autoExitOnQuiet: true });
+
+		const handsFreeHarness = await setupExtensionHarness();
+		const handsFreeTool = handsFreeHarness.getTool();
+		expect(handsFreeTool).toBeTruthy();
+
+		await handsFreeTool!.execute("call-2", {
+			command: "pi",
+			mode: "hands-free",
+		}, undefined, undefined, handsFreeHarness.ctx as any);
+		expect(handsFreeHarness.getLastOverlayOptions()).toMatchObject({ mode: "hands-free", autoExitOnQuiet: false });
 	});
 
 	it("interactive_shell structured spawn supports native startup prompts", async () => {

--- a/tool-schema.ts
+++ b/tool-schema.ts
@@ -270,7 +270,7 @@ export const toolParameters = Type.Object({
 			),
 			autoExitOnQuiet: Type.Optional(
 				Type.Boolean({
-					description: "Auto-kill session when output stops (after quietThreshold). Defaults to false. Set to true for fire-and-forget single-task delegations.",
+					description: "Auto-kill session when output stops (after quietThreshold). Defaults to true in dispatch mode and false in hands-free mode.",
 				}),
 			),
 		}),


### PR DESCRIPTION
## Summary

- keep completed foreground and reattached dispatch output queryable for the five-minute cleanup window
- keep the existing dispatch quiet auto-close default unchanged
- restore immediate PTY disposal for non-dispatch active completions
- fix the `handsFree.autoExitOnQuiet` schema text so it matches the actual per-mode defaults
- credit @gwelinder for the useful retained-output slice from #43

This replaces #43 with the smaller accepted behavior while leaving the rejected wait-for-exit-by-default change out of scope.

## Validation

- `npx vitest run tests/overlay-render.test.ts tests/session-manager.test.ts tests/spawn-command.test.ts tests/dispatch-background-recovery.test.ts tests/config-and-docs.test.ts --silent`
- `npm run typecheck`
- `git diff --check origin/main...HEAD`
- `npx vitest run --silent`
- fresh review: No issues found
- exact-head review on `8f15384`: No issues found