### PR TITLE
chore: deslop interactive shell cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to the `pi-interactive-shell` extension will be documented i
 ## [Unreleased]
 
 ### Fixed
+- Clean up Codex workflow docs, monitor query diagnostics, detector-command validation, spawn worktree setup errors, and completed-session details.
 - Keep completed foreground or reattached dispatch output queryable for the documented five-minute cleanup window. Thanks to [@gwelinder](https://github.com/gwelinder) for #43.
 - Prevent stale background-widget cleanup from reusing an expired session context after `/clear` or session replacement (#42, reported by [@luluxiang06](https://github.com/luluxiang06)).
 - Expose dispatch quiet auto-close as `completionReason: "auto-close-quiet"` and mark it as non-terminal in notifications.

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ The `interactive-shell` skill is automatically symlinked to `~/.pi/agent/skills/
 
 **Dispatch** — Returns immediately. No polling. The agent gets woken up via `triggerTurn` only when the session completes (natural exit, timeout, quiet detection, or user kill). The notification includes a tail of the output. This is the default for delegating work to subagents. Add `background: true` to skip the overlay entirely.
 
-**Monitor** — Returns immediately. No polling, no completion notification. The agent gets woken up when a configured monitor trigger emits an event. Supports stream triggers, poll-diff checks, first-class file watching, optional cooldowns, persistence controls, detector commands, and event history queries. Runs headless; attach to inspect if needed.
+**Monitor** — Returns immediately. The agent gets woken up when a configured monitor trigger emits an event, and when the monitor lifecycle stops. Supports stream triggers, poll-diff checks, first-class file watching, optional cooldowns, persistence controls, detector commands, and event history queries. Runs headless; attach to inspect if needed.
 
 ## Quick Start
 
@@ -533,7 +533,7 @@ Full PTY. The subprocess thinks it's in a real terminal.
 
 ## Example Workflow: Plan, Implement, Review
 
-The `examples/prompts/` directory includes three opt-in prompt templates that chain together into a complete development workflow using Codex CLI. Each template loads the example `gpt-5-4-prompting` skill by default, falls back to `codex-5-3-prompting` when the user explicitly asks for Codex 5.3, and launches Codex in an interactive overlay.
+The `examples/prompts/` directory includes three opt-in prompt templates that chain together into a complete development workflow using Codex CLI. Each template loads the example `gpt-5-4-prompting` skill by default, falls back to `codex-5-3-prompting` when the user explicitly asks for Codex 5.3, and launches Codex in an interactive overlay with Codex CLI's preferred `gpt-5.5` model.
 
 ### The Pipeline
 
@@ -603,7 +603,7 @@ These templates demonstrate a "meta-prompt generation" pattern:
 
 1. **Pi gathers context** — reads the plan, runs git diff, and loads the copied local `gpt-5-4-prompting` or `codex-5-3-prompting` skill
 2. **Pi generates a calibrated prompt** — tailored to the specific plan/diff, following the selected skill's best practices
-3. **Pi launches Codex in the overlay** — defaulting to `-m gpt-5.4 -a never` and switching to `-m gpt-5.3-codex -a never` only when the user explicitly asks for Codex 5.3
+3. **Pi launches Codex in the overlay** — defaulting to `-m gpt-5.5 -a never` and switching to `-m gpt-5.3-codex -a never` only when the user explicitly asks for Codex 5.3
 
 The user watches Codex work in the overlay and can take over anytime (type to intervene, Ctrl+T to transfer output back to pi, Ctrl+Q for options).
 

--- a/background-widget.ts
+++ b/background-widget.ts
@@ -1,12 +1,29 @@
 import { truncateToWidth, visibleWidth } from "@earendil-works/pi-tui";
 import { formatDuration } from "./types.ts";
-import type { ShellSessionManager } from "./session-manager.ts";
+import type { ExtensionContext, Theme } from "@earendil-works/pi-coding-agent";
+import type { TUI } from "@earendil-works/pi-tui";
 import type { InteractiveShellCoordinator } from "./runtime-coordinator.ts";
 
+type BackgroundWidgetContext = Pick<ExtensionContext, "hasUI"> & {
+	ui: Pick<ExtensionContext["ui"], "setWidget">;
+};
+type BackgroundWidgetSession = {
+	id: string;
+	command: string;
+	reason?: string;
+	startedAt: Date;
+	session: { exited: boolean };
+};
+type BackgroundWidgetSessionManager = {
+	onChange: (listener: () => void) => () => void;
+	list: () => BackgroundWidgetSession[];
+};
+type BackgroundWidgetCoordinator = Pick<InteractiveShellCoordinator, "getMonitorSessionState">;
+
 export function setupBackgroundWidget(
-	ctx: { ui: { setWidget: Function }; hasUI?: boolean },
-	sessionManager: ShellSessionManager,
-	coordinator?: InteractiveShellCoordinator,
+	ctx: BackgroundWidgetContext,
+	sessionManager: BackgroundWidgetSessionManager,
+	coordinator?: BackgroundWidgetCoordinator,
 ): (() => void) | null {
 	if (!ctx.hasUI) return null;
 
@@ -32,7 +49,7 @@ export function setupBackgroundWidget(
 
 	ctx.ui.setWidget(
 		"bg-sessions",
-		(tui: any, theme: any) => {
+		(tui: TUI, theme: Theme) => {
 			tuiRef = tui;
 			return {
 				render: (width: number) => {

--- a/examples/prompts/codex-implement-plan.md
+++ b/examples/prompts/codex-implement-plan.md
@@ -2,7 +2,7 @@
 description: Launch Codex CLI in overlay to fully implement an existing plan/spec document
 ---
 Determine which prompting skill to load based on model:
-- Default: Load `gpt-5-4-prompting` skill (for `gpt-5.4`)
+- Default: Load `gpt-5-4-prompting` skill (for Codex CLI `gpt-5.5`)
 - If user explicitly requests Codex 5.3: Load `codex-5-3-prompting` skill (for `gpt-5.3-codex`)
 
 Also load the `codex-cli` skill. Then read the plan at `$1`.
@@ -24,7 +24,7 @@ Based on the prompting skill's best practices and the plan's content, generate a
 The meta prompt should follow the prompting skill's patterns: clear system context, explicit scope and verbosity constraints, step-by-step instructions, and expected output format. Instruct Codex not to ask clarifying questions about things answerable by reading the plan or codebase — read first, then act. Keep progress updates brief and concrete (no narrating routine file reads or tool calls). Emphasize that the plan has already been thoroughly reviewed — the job is faithful execution, not second-guessing the design. Emphasize scope discipline and verification requirements per the prompting skill.
 
 Determine the model flag:
-- Default: `-m gpt-5.4`
+- Default: `-m gpt-5.5`
 - If user explicitly requests Codex 5.3: `-m gpt-5.3-codex`
 
 Then launch Codex CLI in the interactive shell overlay with that meta prompt using the chosen model flag plus `-a never`.

--- a/examples/prompts/codex-review-impl.md
+++ b/examples/prompts/codex-review-impl.md
@@ -2,7 +2,7 @@
 description: Launch Codex CLI in overlay to review implemented code changes (optionally against a plan)
 ---
 Determine which prompting skill to load based on model:
-- Default: Load `gpt-5-4-prompting` skill (for `gpt-5.4`)
+- Default: Load `gpt-5-4-prompting` skill (for Codex CLI `gpt-5.5`)
 - If user explicitly requests Codex 5.3: Load `codex-5-3-prompting` skill (for `gpt-5.3-codex`)
 
 Also load the `codex-cli` skill. Then determine the review scope:
@@ -25,7 +25,7 @@ Based on the prompting skill's best practices, the diff scope, and the optional 
 The meta prompt should follow the prompting skill's patterns: clear system context, explicit scope and verbosity constraints, step-by-step instructions, and expected output format. Instruct Codex not to ask clarifying questions — if intent is unclear, read the surrounding code for context instead of asking. Keep progress updates brief and concrete (no narrating routine file reads or tool calls). Emphasize thoroughness — read the actual code deeply before making judgments, question every assumption, and never rubber-stamp. Emphasize scope discipline and verification requirements per the prompting skill.
 
 Determine the model flag:
-- Default: `-m gpt-5.4`
+- Default: `-m gpt-5.5`
 - If user explicitly requests Codex 5.3: `-m gpt-5.3-codex`
 
 Then launch Codex CLI in the interactive shell overlay with that meta prompt using the chosen model flag plus `-a never`.

--- a/examples/prompts/codex-review-plan.md
+++ b/examples/prompts/codex-review-plan.md
@@ -2,7 +2,7 @@
 description: Launch Codex CLI in overlay to review an implementation plan against the codebase
 ---
 Determine which prompting skill to load based on model:
-- Default: Load `gpt-5-4-prompting` skill (for `gpt-5.4`)
+- Default: Load `gpt-5-4-prompting` skill (for Codex CLI `gpt-5.5`)
 - If user explicitly requests Codex 5.3: Load `codex-5-3-prompting` skill (for `gpt-5.3-codex`)
 
 Also load the `codex-cli` skill. Then read the plan at `$1`.
@@ -19,7 +19,7 @@ Based on the prompting skill's best practices and the plan's content, generate a
 The meta prompt should follow the prompting skill's patterns (clear system context, explicit constraints, step-by-step instructions, expected output format). Instruct Codex not to ask clarifying questions — read the codebase to resolve ambiguities instead of asking. Keep progress updates brief and concrete. Emphasize scope discipline and verification requirements per the prompting skill.
 
 Determine the model flag:
-- Default: `-m gpt-5.4`
+- Default: `-m gpt-5.5`
 - If user explicitly requests Codex 5.3: `-m gpt-5.3-codex`
 
 Then launch Codex CLI in the interactive shell overlay with that meta prompt using the chosen model flag plus `-a never`.

--- a/index.ts
+++ b/index.ts
@@ -15,7 +15,7 @@ import type {
 	MonitorThresholdOperator,
 	MonitorTriggerConfig,
 } from "./types.ts";
-import { sessionManager, generateSessionId } from "./session-manager.ts";
+import { sessionManager, generateSessionId, type ActiveSession } from "./session-manager.ts";
 import { loadConfig } from "./config.ts";
 import type { InteractiveShellConfig } from "./config.ts";
 import { isEmptySpawnPlaceholder, normalizeSpawnRequest, parseSpawnArgs, resolveSpawn, type SpawnRequest } from "./spawn.ts";
@@ -146,6 +146,61 @@ type DetectorDecision = {
 	matchedText?: string;
 	lineOrDiff?: string;
 };
+
+function parseDetectorDecision(raw: string): DetectorDecision {
+	const parsed = JSON.parse(raw) as unknown;
+	if (typeof parsed === "boolean") {
+		return { emit: parsed };
+	}
+	if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed) || Object.getPrototypeOf(parsed) !== Object.prototype) {
+		throw new Error("detectorCommand returned invalid decision: expected boolean or object");
+	}
+	const decision = parsed as Record<string, unknown>;
+	if (decision.emit !== undefined && typeof decision.emit !== "boolean") {
+		throw new Error("detectorCommand returned invalid decision: emit must be boolean");
+	}
+	for (const key of ["triggerId", "eventType", "matchedText", "lineOrDiff"] as const) {
+		if (decision[key] !== undefined && typeof decision[key] !== "string") {
+			throw new Error(`detectorCommand returned invalid decision: ${key} must be string`);
+		}
+	}
+	const result: DetectorDecision = { emit: decision.emit !== false };
+	if (typeof decision.triggerId === "string") result.triggerId = decision.triggerId;
+	if (typeof decision.eventType === "string") result.eventType = decision.eventType;
+	if (typeof decision.matchedText === "string") result.matchedText = decision.matchedText;
+	if (typeof decision.lineOrDiff === "string") result.lineOrDiff = decision.lineOrDiff;
+	return result;
+}
+
+function completedSessionDetails(
+	sessionId: string,
+	status: string,
+	runtime: number,
+	output: string,
+	outputTruncated: boolean,
+	outputTotalBytes: number,
+	outputTotalLines: number | undefined,
+	hasMore: boolean | undefined,
+	result: ReturnType<ActiveSession["getResult"]>,
+) {
+	return {
+		sessionId,
+		status,
+		runtime,
+		output,
+		outputTruncated,
+		outputTotalBytes,
+		outputTotalLines,
+		hasMore,
+		exitCode: result?.exitCode,
+		signal: result?.signal,
+		backgroundId: result?.backgroundId,
+		completionReason: result?.completionReason,
+		timedOut: result?.timedOut,
+		cancelled: result?.cancelled,
+		completionOutput: result?.completionOutput,
+	};
+}
 
 function buildPollDiffLoopCommand(command: string, intervalMs: number): string {
 	if (process.platform === "win32") {
@@ -473,20 +528,13 @@ async function runDetectorCommand(
 				return;
 			}
 			try {
-				const parsed = JSON.parse(raw) as DetectorDecision | boolean;
-				if (typeof parsed === "boolean") {
-					resolve({ emit: parsed });
+				resolve(parseDetectorDecision(raw));
+			} catch (error) {
+				if (error instanceof SyntaxError) {
+					reject(new Error(`detectorCommand returned invalid JSON: ${error.message}`));
 					return;
 				}
-				resolve({
-					emit: parsed.emit !== false,
-					triggerId: parsed.triggerId,
-					eventType: parsed.eventType,
-					matchedText: parsed.matchedText,
-					lineOrDiff: parsed.lineOrDiff,
-				});
-			} catch (error) {
-				reject(new Error(`detectorCommand returned invalid JSON: ${(error as Error).message}`));
+				reject(error);
 			}
 		});
 
@@ -1296,13 +1344,21 @@ export default function interactiveShellExtension(pi: ExtensionAPI) {
 					};
 				}
 
+				const state = coordinator.getMonitorSessionState(targetMonitorSessionId);
+				if (state === undefined) {
+					return {
+						content: [{ type: "text", text: `Monitor session not found: ${targetMonitorSessionId}` }],
+						isError: true,
+						details: { sessionId: targetMonitorSessionId, state: null, events: [], total: 0 },
+					};
+				}
+
 				const history = coordinator.getMonitorEvents(targetMonitorSessionId, {
 					limit: monitorEventLimit,
 					offset: monitorEventOffset,
 					sinceEventId: monitorSinceEventId,
 					triggerId: monitorTriggerId,
 				});
-				const state = coordinator.getMonitorSessionState(targetMonitorSessionId);
 				if (history.total === 0) {
 					return {
 						content: [{ type: "text", text: `No monitor events for session ${targetMonitorSessionId}.` }],
@@ -1447,7 +1503,7 @@ export default function interactiveShellExtension(pi: ExtensionAPI) {
 						}
 						return {
 							content: [{ type: "text", text: `Session ${sessionId} ${status} after ${formatDurationMs(runtime)}${hasOutput ? `\n\nOutput${truncatedNote}${hasMoreNote}:\n${output}` : ""}` }],
-							details: { sessionId, status, runtime, output, outputTruncated: truncated, outputTotalBytes: totalBytes, outputTotalLines: totalLines, hasMore, exitCode: result.exitCode, signal: result.signal, backgroundId: result.backgroundId },
+							details: completedSessionDetails(sessionId, status, runtime, output, truncated, totalBytes, totalLines, hasMore, result),
 						};
 					}
 
@@ -1478,7 +1534,7 @@ export default function interactiveShellExtension(pi: ExtensionAPI) {
 								}
 								return {
 									content: [{ type: "text", text: `Session ${sessionId} ${earlyStatus} after ${formatDurationMs(earlyRuntime)}${hasOutput ? `\n\nOutput${truncatedNote}${hasMoreNote}:\n${output}` : ""}` }],
-									details: { sessionId, status: earlyStatus, runtime: earlyRuntime, output, outputTruncated: truncated, outputTotalBytes: totalBytes, outputTotalLines: totalLines, hasMore, exitCode: earlyResult.exitCode, signal: earlyResult.signal, backgroundId: earlyResult.backgroundId },
+									details: completedSessionDetails(sessionId, earlyStatus, earlyRuntime, output, truncated, totalBytes, totalLines, hasMore, earlyResult),
 								};
 							}
 							return {
@@ -1500,7 +1556,7 @@ export default function interactiveShellExtension(pi: ExtensionAPI) {
 							}
 							return {
 								content: [{ type: "text", text: `Session ${sessionId} ${freshStatus} after ${formatDurationMs(freshRuntime)}${hasOutput ? `\n\nOutput${truncatedNote}${hasMoreNote}:\n${freshOutput.output}` : ""}` }],
-								details: { sessionId, status: freshStatus, runtime: freshRuntime, output: freshOutput.output, outputTruncated: freshOutput.truncated, outputTotalBytes: freshOutput.totalBytes, outputTotalLines: freshOutput.totalLines, hasMore: freshOutput.hasMore, exitCode: freshResult.exitCode, signal: freshResult.signal, backgroundId: freshResult.backgroundId },
+								details: completedSessionDetails(sessionId, freshStatus, freshRuntime, freshOutput.output, freshOutput.truncated, freshOutput.totalBytes, freshOutput.totalLines, freshOutput.hasMore, freshResult),
 							};
 						}
 						return {

--- a/overlay-component.ts
+++ b/overlay-component.ts
@@ -154,23 +154,7 @@ export class InteractiveShellOverlay implements Component, Focusable {
 		}
 		if (options.sessionId || this.state === "hands-free") {
 			this.sessionId = options.sessionId ?? generateSessionId(options.name);
-			sessionManager.registerActive({
-				id: this.sessionId,
-				command: options.command,
-				reason: options.reason,
-				write: (data) => this.session.write(data),
-				kill: () => this.killSession(),
-				background: () => this.backgroundSession(),
-				getOutput: (options) => this.getOutputSinceLastCheck(options),
-				getStatus: () => this.getSessionStatus(),
-				getRuntime: () => this.getRuntime(),
-				getResult: () => this.getCompletionResult(),
-				dispose: () => this.disposeTerminalSession(),
-				retainAfterCompletion: this.options.mode === "dispatch",
-				setUpdateInterval: (intervalMs) => this.setUpdateInterval(intervalMs),
-				setQuietThreshold: (thresholdMs) => this.setQuietThreshold(thresholdMs),
-				onComplete: (callback) => this.registerCompleteCallback(callback),
-			});
+			this.registerActiveSession();
 		}
 		if (this.state === "hands-free") {
 			this.startHandsFreeUpdates();
@@ -452,6 +436,28 @@ export class InteractiveShellOverlay implements Component, Focusable {
 		}
 	}
 
+	private registerActiveSession(): void {
+		if (!this.sessionId) return;
+		sessionManager.registerActive({
+			id: this.sessionId,
+			command: this.options.command,
+			reason: this.options.reason,
+			write: (data) => this.session.write(data),
+			kill: () => this.killSession(),
+			background: () => this.backgroundSession(),
+			getOutput: (options) => this.getOutputSinceLastCheck(options),
+			getStatus: () => this.getSessionStatus(),
+			getRuntime: () => this.getRuntime(),
+			getResult: () => this.getCompletionResult(),
+			dispose: () => this.disposeTerminalSession(),
+			retainAfterCompletion: this.options.mode === "dispatch",
+			setUpdateInterval: (intervalMs) => this.setUpdateInterval(intervalMs),
+			setQuietThreshold: (thresholdMs) => this.setQuietThreshold(thresholdMs),
+			onComplete: (callback) => this.registerCompleteCallback(callback),
+		});
+		this.sessionUnregistered = false;
+	}
+
 	private disposeTerminalSession(): void {
 		if (this.sessionDisposed) return;
 		this.session.dispose();
@@ -556,24 +562,7 @@ export class InteractiveShellOverlay implements Component, Focusable {
 
 		// Re-register if streaming mode previously released the session
 		if (this.sessionUnregistered) {
-			sessionManager.registerActive({
-				id: this.sessionId,
-				command: this.options.command,
-				reason: this.options.reason,
-				write: (data) => this.session.write(data),
-				kill: () => this.killSession(),
-				background: () => this.backgroundSession(),
-				getOutput: (options) => this.getOutputSinceLastCheck(options),
-				getStatus: () => this.getSessionStatus(),
-				getRuntime: () => this.getRuntime(),
-				getResult: () => this.getCompletionResult(),
-				dispose: () => this.disposeTerminalSession(),
-				retainAfterCompletion: this.options.mode === "dispatch",
-				setUpdateInterval: (intervalMs) => this.setUpdateInterval(intervalMs),
-				setQuietThreshold: (thresholdMs) => this.setQuietThreshold(thresholdMs),
-				onComplete: (callback) => this.registerCompleteCallback(callback),
-			});
-			this.sessionUnregistered = false;
+			this.registerActiveSession();
 		}
 
 		if (this.options.onHandsFreeUpdate) {

--- a/session-manager.ts
+++ b/session-manager.ts
@@ -1,4 +1,5 @@
 import { PtyTerminalSession } from "./pty-session.ts";
+import type { DispatchCompletionReason } from "./types.ts";
 
 export interface BackgroundSession {
 	id: string;
@@ -14,10 +15,16 @@ export type ActiveSessionStatus = "running" | "monitoring" | "user-takeover" | "
 export interface ActiveSessionResult {
 	exitCode: number | null;
 	signal?: number;
+	completionReason?: DispatchCompletionReason;
 	backgrounded?: boolean;
 	backgroundId?: string;
 	cancelled?: boolean;
 	timedOut?: boolean;
+	completionOutput?: {
+		lines: string[];
+		totalLines: number;
+		truncated: boolean;
+	};
 }
 
 export interface OutputResult {

--- a/skills/pi-interactive-shell/SKILL.md
+++ b/skills/pi-interactive-shell/SKILL.md
@@ -5,8 +5,6 @@ description: Cheat sheet + workflow for launching interactive coding-agent CLIs 
 
 # Interactive Shell (Skill)
 
-Last verified: 2026-08-12
-
 ## Deferred activation
 
 When `interactive_shell` is unavailable, call `enable_interactive_shell` first. The tool becomes callable on the next turn and stays active until Pi reloads or the session changes; reloaded, new, resumed, and forked sessions reset it to inactive. Do not call the loader when `interactive_shell` is already available.

--- a/spawn.ts
+++ b/spawn.ts
@@ -235,7 +235,11 @@ function createSpawnWorktree(
 	const baseDir = config.spawn.worktreeBaseDir
 		? resolve(repoRoot.stdout, config.spawn.worktreeBaseDir)
 		: join(dirname(repoRoot.stdout), `${basename(repoRoot.stdout)}-worktrees`);
-	mkdirSync(baseDir, { recursive: true });
+	try {
+		mkdirSync(baseDir, { recursive: true });
+	} catch (error) {
+		return { ok: false, error: `Failed to create worktree base directory: ${(error as Error).message}` };
+	}
 
 	const timestamp = new Date().toISOString().replace(/[-:.]/g, "").replace("T", "-").replace("Z", "");
 	const suffix = Math.random().toString(36).slice(2, 7);

--- a/tests/background-widget.test.ts
+++ b/tests/background-widget.test.ts
@@ -25,10 +25,15 @@ describe("setupBackgroundWidget cleanup", () => {
 				events.push("unsubscribe");
 				unsubscribe();
 			}),
-			list: vi.fn(() => [{ session: { exited: false } }]),
-		};
+			list: vi.fn(() => [{
+				id: "bg-1",
+				command: "pi \"work\"",
+				startedAt: new Date("2026-08-26T00:00:00.000Z"),
+				session: { exited: false },
+			}]),
+		} satisfies Parameters<typeof setupBackgroundWidget>[1];
 
-		const cleanup = setupBackgroundWidget(ctx, sessionManager as any);
+		const cleanup = setupBackgroundWidget(ctx, sessionManager);
 		expect(cleanup).toBeTypeOf("function");
 		expect(vi.getTimerCount()).toBe(1);
 

--- a/tests/monitor-mode.test.ts
+++ b/tests/monitor-mode.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { EventEmitter } from "node:events";
 
 type MonitorOptionsCapture = {
 	monitor?: {
@@ -11,16 +12,36 @@ type MonitorOptionsCapture = {
 	onMonitorEvent?: (event: unknown) => void | Promise<void>;
 } | null;
 
-async function setupHarness() {
+async function setupHarness(options: { detectorStdout?: string } = {}) {
 	let toolDef: any;
 	let monitorOptions: MonitorOptionsCapture = null;
 	let launchedCommand: string | undefined;
 	let monitorCompleteCallback: ((info: unknown) => void) | undefined;
+	let activeSession: unknown;
 	const sendMessage = vi.fn();
 
 	vi.resetModules();
 	vi.doMock("@earendil-works/pi-coding-agent", () => ({
 		getAgentDir: () => "/tmp/pi-agent",
+	}));
+	vi.doMock("node:child_process", () => ({
+		spawn: vi.fn(() => {
+			const child = new EventEmitter() as EventEmitter & {
+				stdout: EventEmitter & { setEncoding: (encoding: string) => void };
+				stderr: EventEmitter & { setEncoding: (encoding: string) => void };
+				stdin: { write: (data: string) => void; end: () => void };
+				kill: () => void;
+			};
+			child.stdout = Object.assign(new EventEmitter(), { setEncoding: vi.fn() });
+			child.stderr = Object.assign(new EventEmitter(), { setEncoding: vi.fn() });
+			child.stdin = { write: vi.fn(), end: vi.fn() };
+			child.kill = vi.fn();
+			process.nextTick(() => {
+				child.stdout.emit("data", options.detectorStdout ?? "");
+				child.emit("exit", 0);
+			});
+			return child;
+		}),
 	}));
 	vi.doMock("@earendil-works/pi-tui", () => ({
 		isKeyRelease: () => false,
@@ -111,7 +132,7 @@ async function setupHarness() {
 	}));
 	vi.doMock("../session-manager.ts", () => ({
 		sessionManager: {
-			getActive: vi.fn(() => undefined),
+			getActive: vi.fn(() => activeSession),
 			unregisterActive: vi.fn(),
 			registerActive: vi.fn(),
 			list: vi.fn(() => []),
@@ -148,6 +169,7 @@ async function setupHarness() {
 		getMonitorOptions: () => monitorOptions,
 		getLaunchedCommand: () => launchedCommand,
 		getMonitorCompleteCallback: () => monitorCompleteCallback,
+		setActiveSession: (session: unknown) => { activeSession = session; },
 		sendMessage,
 	};
 }
@@ -155,6 +177,7 @@ async function setupHarness() {
 describe("monitor mode", () => {
 	afterEach(() => {
 		vi.doUnmock("@earendil-works/pi-coding-agent");
+		vi.doUnmock("node:child_process");
 		vi.doUnmock("@earendil-works/pi-tui");
 		vi.doUnmock("../config.ts");
 		vi.doUnmock("../overlay-component.ts");
@@ -234,6 +257,28 @@ describe("monitor mode", () => {
 
 		expect(result.isError).toBe(true);
 		expect(result.content[0].text).toContain("monitorEvents requires monitorSessionId");
+	});
+
+	it("returns an error for unknown monitorEvents session ids", async () => {
+		const { toolDef } = await setupHarness();
+		const result = await toolDef.execute("call-1", {
+			monitorEvents: true,
+			monitorSessionId: "missing-monitor",
+		}, undefined, undefined, {
+			hasUI: false,
+			cwd: "/tmp/project",
+			ui: {},
+			sessionManager: { getSessionFile: () => "/tmp/project/session.jsonl" },
+		} as any);
+
+		expect(result.isError).toBe(true);
+		expect(result.content[0].text).toContain("Monitor session not found: missing-monitor");
+		expect(result.details).toEqual({
+			sessionId: "missing-monitor",
+			state: null,
+			events: [],
+			total: 0,
+		});
 	});
 
 	it("wraps poll-diff monitor command into a recurring loop", async () => {
@@ -435,6 +480,84 @@ describe("monitor mode", () => {
 		expect(filtered.details.events[0]?.triggerId).toBe("warn");
 		expect(filtered.details.sinceEventId).toBe(1);
 		expect(filtered.details.triggerId).toBe("warn");
+	});
+
+	it("rejects detectorCommand decisions with invalid shapes", async () => {
+		const harness = await setupHarness({ detectorStdout: "[]" });
+		const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+		try {
+			await harness.toolDef.execute("call-1", {
+				command: "npm test --watch",
+				mode: "monitor",
+				monitor: {
+					strategy: "stream",
+					triggers: [{ id: "fail", literal: "FAIL" }],
+					detector: { detectorCommand: "printf '[]'" },
+				},
+			}, undefined, undefined, {
+				hasUI: false,
+				cwd: "/tmp/project",
+				ui: {},
+				sessionManager: { getSessionFile: () => "/tmp/project/session.jsonl" },
+			} as any);
+
+			harness.getMonitorOptions()?.onMonitorEvent?.({
+				strategy: "stream",
+				triggerId: "fail",
+				eventType: "fail",
+				matchedText: "FAIL",
+				lineOrDiff: "FAIL first",
+				stream: "pty",
+			});
+			await new Promise((resolve) => setTimeout(resolve, 20));
+
+			expect(harness.sendMessage).not.toHaveBeenCalledWith(
+				expect.objectContaining({ customType: "interactive-shell-monitor-event" }),
+				expect.any(Object),
+			);
+			expect(consoleError).toHaveBeenCalledWith(
+				"interactive-shell: detectorCommand failed for monitor-1:",
+				expect.objectContaining({ message: "detectorCommand returned invalid decision: expected boolean or object" }),
+			);
+		} finally {
+			consoleError.mockRestore();
+		}
+	});
+
+	it("includes dispatch completion fields in completed active-session query details", async () => {
+		const harness = await setupHarness();
+		harness.setActiveSession({
+			retainAfterCompletion: true,
+			getResult: vi.fn(() => ({
+				exitCode: null,
+				completionReason: "auto-close-quiet",
+				timedOut: false,
+				cancelled: true,
+				completionOutput: { lines: ["done"], totalLines: 1, truncated: false },
+			})),
+			getOutput: vi.fn(() => ({ output: "done", truncated: false, totalBytes: 4, totalLines: 1, hasMore: false })),
+			getStatus: vi.fn(() => "exited"),
+			getRuntime: vi.fn(() => 1200),
+			onComplete: vi.fn(),
+		});
+
+		const result = await harness.toolDef.execute("call-1", {
+			sessionId: "dispatch-1",
+		}, undefined, undefined, {
+			hasUI: false,
+			cwd: "/tmp/project",
+			ui: {},
+			sessionManager: { getSessionFile: () => "/tmp/project/session.jsonl" },
+		} as any);
+
+		expect(result.isError).not.toBe(true);
+		expect(result.details).toMatchObject({
+			sessionId: "dispatch-1",
+			completionReason: "auto-close-quiet",
+			timedOut: false,
+			cancelled: true,
+			completionOutput: { lines: ["done"], totalLines: 1, truncated: false },
+		});
 	});
 
 	it("emits monitor lifecycle notification when monitor session completes", async () => {

--- a/tests/session-manager.test.ts
+++ b/tests/session-manager.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { ShellSessionManager } from "../session-manager.ts";
+import type { ActiveSession } from "../session-manager.ts";
 
 function createSession() {
 	return {
@@ -7,6 +8,22 @@ function createSession() {
 		setEventHandlers: vi.fn(),
 		dispose: vi.fn(),
 		kill: vi.fn(),
+	};
+}
+
+function createActiveSession(overrides: Partial<ActiveSession> = {}): ActiveSession {
+	return {
+		id: "active-1",
+		command: "pi \"active\"",
+		write: vi.fn(),
+		kill: vi.fn(),
+		background: vi.fn(),
+		getOutput: vi.fn(() => ({ output: "", truncated: false, totalBytes: 0 })),
+		getStatus: vi.fn((): ActiveSession["getStatus"] extends () => infer Status ? Status : never => "running"),
+		getRuntime: vi.fn(() => 0),
+		getResult: vi.fn(() => undefined),
+		onComplete: vi.fn(),
+		...overrides,
 	};
 }
 
@@ -45,19 +62,7 @@ describe("ShellSessionManager", () => {
 		const manager = new ShellSessionManager();
 		const dispose = vi.fn();
 
-		manager.registerActive({
-			id: "active-1",
-			command: "pi \"active\"",
-			write: vi.fn(),
-			kill: vi.fn(),
-			background: vi.fn(),
-			getOutput: vi.fn() as any,
-			getStatus: vi.fn() as any,
-			getRuntime: vi.fn() as any,
-			getResult: vi.fn() as any,
-			dispose,
-			onComplete: vi.fn(),
-		});
+		manager.registerActive(createActiveSession({ dispose }));
 		manager.scheduleCleanup("active-1", 5 * 60 * 1000);
 
 		vi.advanceTimersByTime(5 * 60 * 1000);
@@ -71,51 +76,15 @@ describe("ShellSessionManager", () => {
 		const staleDispose = vi.fn();
 		const nextDispose = vi.fn();
 
-		manager.registerActive({
-			id: "active-1",
-			command: "pi \"active\"",
-			write: vi.fn(),
-			kill: vi.fn(),
-			background: vi.fn(),
-			getOutput: vi.fn() as any,
-			getStatus: vi.fn() as any,
-			getRuntime: vi.fn() as any,
-			getResult: vi.fn() as any,
-			dispose: staleDispose,
-			onComplete: vi.fn(),
-		});
+		manager.registerActive(createActiveSession({ dispose: staleDispose }));
 		manager.scheduleCleanup("active-1", 1000);
 		manager.unregisterActive("active-1");
 		vi.advanceTimersByTime(1000);
 		expect(staleDispose).not.toHaveBeenCalled();
 
-		manager.registerActive({
-			id: "active-1",
-			command: "pi \"active\"",
-			write: vi.fn(),
-			kill: vi.fn(),
-			background: vi.fn(),
-			getOutput: vi.fn() as any,
-			getStatus: vi.fn() as any,
-			getRuntime: vi.fn() as any,
-			getResult: vi.fn() as any,
-			dispose: staleDispose,
-			onComplete: vi.fn(),
-		});
+		manager.registerActive(createActiveSession({ dispose: staleDispose }));
 		manager.scheduleCleanup("active-1", 1000);
-		manager.registerActive({
-			id: "active-1",
-			command: "pi \"next\"",
-			write: vi.fn(),
-			kill: vi.fn(),
-			background: vi.fn(),
-			getOutput: vi.fn() as any,
-			getStatus: vi.fn() as any,
-			getRuntime: vi.fn() as any,
-			getResult: vi.fn() as any,
-			dispose: nextDispose,
-			onComplete: vi.fn(),
-		});
+		manager.registerActive(createActiveSession({ command: "pi \"next\"", dispose: nextDispose }));
 		vi.advanceTimersByTime(1000);
 		expect(staleDispose).not.toHaveBeenCalled();
 		expect(nextDispose).not.toHaveBeenCalled();
@@ -128,18 +97,7 @@ describe("ShellSessionManager", () => {
 		manager.add("pi \"bg\"", backgroundSession, undefined, undefined, { id: "bg-1" });
 
 		const activeKill = vi.fn();
-		manager.registerActive({
-			id: "active-1",
-			command: "pi \"active\"",
-			write: vi.fn(),
-			kill: activeKill,
-			background: vi.fn(),
-			getOutput: vi.fn() as any,
-			getStatus: vi.fn() as any,
-			getRuntime: vi.fn() as any,
-			getResult: vi.fn() as any,
-			onComplete: vi.fn(),
-		});
+		manager.registerActive(createActiveSession({ kill: activeKill }));
 
 		manager.killAll();
 		expect(backgroundSession.dispose).toHaveBeenCalledTimes(1);

--- a/tests/spawn.test.ts
+++ b/tests/spawn.test.ts
@@ -263,4 +263,29 @@ describe("spawn helpers", () => {
 		expect(result.spawn.reason).toContain("worktree:");
 		expect(execFileSync).toHaveBeenCalledTimes(2);
 	});
+
+	it("returns resolver error shape when worktree base directory creation fails", async () => {
+		const execFileSync = vi.fn((command: string, args: string[]) => {
+			expect(command).toBe("git");
+			if (args.includes("rev-parse")) {
+				return "/tmp/repo\n";
+			}
+			throw new Error("unexpected git invocation");
+		});
+		vi.doMock("node:child_process", () => ({ execFileSync }));
+		vi.doMock("node:fs", async () => {
+			const actual = await vi.importActual<typeof import("node:fs")>("node:fs");
+			return {
+				...actual,
+				existsSync: vi.fn(() => true),
+				mkdirSync: vi.fn(() => { throw new Error("EACCES: permission denied, mkdir '/tmp/worktrees'"); }),
+			};
+		});
+		const { resolveSpawn } = await import("../spawn.ts");
+		expect(resolveSpawn(config, "/tmp/repo/packages/app", { agent: "codex", worktree: true }, () => "/tmp/repo/session.jsonl")).toEqual({
+			ok: false,
+			error: "Failed to create worktree base directory: EACCES: permission denied, mkdir '/tmp/worktrees'",
+		});
+		expect(execFileSync).toHaveBeenCalledTimes(1);
+	});
 });


### PR DESCRIPTION
## Summary

- align Codex workflow docs with the current `gpt-5.5` Codex CLI default
- tighten monitor diagnostics and detector-command decision validation
- preserve completion metadata in completed-session queries
- return structured spawn worktree setup errors
- remove small type and duplication slop in widget and session test seams

## Validation

- `npx vitest run tests/monitor-mode.test.ts tests/spawn.test.ts tests/session-manager.test.ts tests/background-widget.test.ts --silent`
- `npm run typecheck`
- `git diff --check`
- `npx vitest run --silent`
- fresh review: No issues found