### PR TITLE
fix: align interactive shell selection with Pi Bash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to the `pi-interactive-shell` extension will be documented i
 
 ## [Unreleased]
 
+### Changed
+- Run new interactive PTYs, generated monitor commands, and detector commands through Pi's Bash selection on every platform, preserving generated argument contents and detector JSON stdin. Thanks to [@lazyst](https://github.com/lazyst) for [#51](https://github.com/nicobailon/pi-interactive-shell/issues/51).
+- Document Unix Bash defaults, Windows Git Bash discovery, `shellPath`, and the unsupported legacy WSL stdin transport for interactive PTYs.
+
 ## [0.15.1] - 2026-08-26
 
 ### Highlights

--- a/README.md
+++ b/README.md
@@ -437,6 +437,30 @@ Configuration files (project overrides global):
 - **Global:** `~/.pi/agent/interactive-shell.json`
 - **Project:** `.pi/interactive-shell.json`
 
+### Shell selection
+
+New sessions use the same Bash resolver as Pi rather than the ambient `$SHELL`
+or `COMSPEC`. On Unix, this changes the default from `$SHELL`/`/bin/sh` to
+Pi's Bash selection (`/bin/bash`, then `bash` on `PATH`, with Pi's documented
+fallback). On Windows, Pi discovers Git Bash in its standard install
+locations, then `bash.exe` on `PATH`.
+
+To choose a specific Bash executable, set Pi's `shellPath` in
+`~/.pi/agent/settings.json` (or trusted project `.pi/settings.json`):
+
+```json
+{
+  "shellPath": "C:/Program Files/Git/bin/bash.exe"
+}
+```
+
+Project settings follow Pi's trust rules: a trusted project's `shellPath`
+overrides the global setting, while an untrusted project's setting is ignored.
+`shellPath` must select a Bash-compatible executable; PowerShell and `cmd.exe`
+are not interactive-shell transports. Pi's legacy WSL `bash.exe` uses
+stdin-only command transport and is rejected for interactive PTYs; select Git
+Bash instead.
+
 Deferred loading and shortcut settings are pinned at startup. If you change `defer`, `focusShortcut`, or `spawn.shortcut`, reload or restart Pi to apply them.
 
 ```json

--- a/index.ts
+++ b/index.ts
@@ -43,6 +43,7 @@ import { buildDispatchNotification, buildHandsFreeUpdateMessage, buildMonitorEve
 import { createSessionQueryState, getSessionOutput } from "./session-query.ts";
 import { InteractiveShellCoordinator } from "./runtime-coordinator.ts";
 import { spawn as spawnChildProcess } from "node:child_process";
+import { resolvePiShell, type ResolvedShellConfig } from "./shell-resolution.ts";
 
 const coordinator = new InteractiveShellCoordinator();
 const SIDE_CHAT_SHORTCUT = "alt+/";
@@ -62,6 +63,11 @@ function scheduleMonitorHistoryCleanup(sessionId: string, delayMs = 5 * 60 * 100
 		coordinator.clearMonitorEvents(sessionId);
 	};
 	setTimeout(attempt, delayMs);
+}
+
+function describeShellResolutionError(error: unknown): string {
+	const message = error instanceof Error ? error.message : String(error);
+	return `Unable to start interactive shell: ${message}`;
 }
 
 function makeMonitorCompletionCallback(
@@ -203,20 +209,16 @@ function completedSessionDetails(
 }
 
 function buildPollDiffLoopCommand(command: string, intervalMs: number): string {
-	if (process.platform === "win32") {
-		const seconds = Math.max(1, Math.ceil(intervalMs / 1000));
-		return `for /L %i in (0,0,1) do (${command} & timeout /t ${seconds} /nobreak >nul)`;
-	}
 	const seconds = Math.max(0.25, intervalMs / 1000);
 	const roundedSeconds = Number(seconds.toFixed(3));
 	return `while true; do ${command}; sleep ${roundedSeconds}; done`;
 }
 
 function shellQuote(value: string): string {
-	if (process.platform === "win32") {
-		return `"${value.replace(/"/g, '""')}"`;
-	}
-	return `'${value.replace(/'/g, `'"'"'`)}'`;
+	// Generated monitor commands run through Pi's Bash selection on every platform.
+	// Bash single quoting keeps `$`, backticks, and backslashes literal; embedded
+	// single quotes close and reopen around the quoted argument.
+	return `'${value.replace(/'/g, `'\\''`)}'`;
 }
 
 function buildFileWatchCommand(fileWatch: Required<MonitorFileWatchConfig>): string {
@@ -483,17 +485,11 @@ function compileMonitorConfig(raw: MonitorConfig | undefined):
 async function runDetectorCommand(
 	detector: NonNullable<CompiledMonitorConfig["detector"]>,
 	candidate: MonitorEventPayload,
+	shellConfig: ResolvedShellConfig,
 	cwd?: string,
 ): Promise<DetectorDecision> {
 	return new Promise<DetectorDecision>((resolve, reject) => {
-		const shell = process.platform === "win32"
-			? (process.env.COMSPEC || "cmd.exe")
-			: (process.env.SHELL || "/bin/sh");
-		const args = process.platform === "win32"
-			? ["/d", "/s", "/c", detector.detectorCommand]
-			: ["-c", detector.detectorCommand];
-
-		const child = spawnChildProcess(shell, args, {
+		const child = spawnChildProcess(shellConfig.shell, [...shellConfig.args, detector.detectorCommand], {
 			cwd,
 			stdio: ["pipe", "pipe", "pipe"],
 			env: process.env,
@@ -547,6 +543,7 @@ function makeMonitorEventCallback(
 	pi: ExtensionAPI,
 	sessionId: string,
 	config: CompiledMonitorConfig,
+	shellConfig: ResolvedShellConfig,
 	cwd?: string,
 ): (event: MonitorMatchInfo) => void {
 	let queue = Promise.resolve();
@@ -578,7 +575,7 @@ function makeMonitorEventCallback(
 						eventId: 0,
 						timestamp: new Date().toISOString(),
 					};
-					const decision = await runDetectorCommand(config.detector, detectorPreview, cwd);
+					const decision = await runDetectorCommand(config.detector, detectorPreview, shellConfig, cwd);
 					if (!decision.emit) return;
 					if (decision.triggerId) candidate = { ...candidate, triggerId: decision.triggerId };
 					if (decision.eventType) candidate = { ...candidate, eventType: decision.eventType };
@@ -769,6 +766,13 @@ export default function interactiveShellExtension(pi: ExtensionAPI) {
 		}
 
 		const config = loadRuntimeConfig(ctx.cwd);
+		let shellConfig: ResolvedShellConfig;
+		try {
+			shellConfig = resolvePiShell(ctx.cwd, ctx.isProjectTrusted?.() ?? false);
+		} catch (error) {
+			ctx.ui.notify(describeShellResolutionError(error), "error");
+			return;
+		}
 		const spawn = resolveSpawn(config, ctx.cwd, request, () => ctx.sessionManager.getSessionFile());
 		if (!spawn.ok) {
 			ctx.ui.notify(spawn.error, "error");
@@ -785,6 +789,7 @@ export default function interactiveShellExtension(pi: ExtensionAPI) {
 					new InteractiveShellOverlay(tui, theme, {
 						command: spawn.spawn.command,
 						cwd: spawn.spawn.cwd,
+						shellConfig,
 						reason: spawn.spawn.reason,
 						onUnfocus: () => coordinator.unfocusOverlay(),
 					}, config, done),
@@ -799,7 +804,7 @@ export default function interactiveShellExtension(pi: ExtensionAPI) {
 		}
 	};
 	const startNewSession = async (params: {
-		ctx: Pick<ExtensionContext, "ui" | "cwd" | "sessionManager"> & { hasUI?: boolean };
+		ctx: Pick<ExtensionContext, "ui" | "cwd" | "sessionManager" | "isProjectTrusted"> & { hasUI?: boolean };
 		command?: string;
 		spawn?: SpawnRequest;
 		cwd?: string;
@@ -850,6 +855,17 @@ export default function interactiveShellExtension(pi: ExtensionAPI) {
 					details: { error: "overlay_already_open" },
 				};
 			}
+		}
+
+		let shellConfig: ResolvedShellConfig;
+		try {
+			// Resolve against Pi's trusted project context, never the command cwd.
+			shellConfig = resolvePiShell(ctx.cwd, ctx.isProjectTrusted?.() ?? false);
+		} catch (error) {
+			return {
+				content: [{ type: "text", text: describeShellResolutionError(error) }],
+				isError: true,
+			};
 		}
 
 		let effectiveCommand = command;
@@ -903,7 +919,7 @@ export default function interactiveShellExtension(pi: ExtensionAPI) {
 
 			const id = generateSessionId(name);
 			const session = new PtyTerminalSession(
-				{ command: monitorCommand, cwd: effectiveCwd, cols: 120, rows: 40, scrollback: config.scrollbackLines },
+				{ command: monitorCommand, shellConfig, cwd: effectiveCwd, cols: 120, rows: 40, scrollback: config.scrollbackLines },
 			);
 			const startTime = Date.now();
 			sessionManager.add(sessionCommand, session, name, effectiveReason, { id, noAutoCleanup: true, startedAt: new Date(startTime) });
@@ -916,7 +932,7 @@ export default function interactiveShellExtension(pi: ExtensionAPI) {
 				timeout,
 				startedAt: startTime,
 				monitor: compiled.runtime,
-				onMonitorEvent: makeMonitorEventCallback(pi, id, compiled, effectiveCwd),
+				onMonitorEvent: makeMonitorEventCallback(pi, id, compiled, shellConfig, effectiveCwd),
 			}, makeStructuredMonitorCompletionCallback(pi, id));
 			registerHeadlessActive(id, sessionCommand, effectiveReason, session, monitorRunner, startTime, config, "monitoring");
 
@@ -937,7 +953,7 @@ export default function interactiveShellExtension(pi: ExtensionAPI) {
 		if (effectiveMode === "dispatch" && background) {
 			const id = generateSessionId(name);
 			const session = new PtyTerminalSession(
-				{ command: launchCommand, cwd: effectiveCwd, cols: 120, rows: 40, scrollback: config.scrollbackLines },
+				{ command: launchCommand, shellConfig, cwd: effectiveCwd, cols: 120, rows: 40, scrollback: config.scrollbackLines },
 			);
 
 			const startTime = Date.now();
@@ -976,6 +992,7 @@ export default function interactiveShellExtension(pi: ExtensionAPI) {
 						new InteractiveShellOverlay(tui, theme, {
 							command: launchCommand,
 							cwd: effectiveCwd,
+							shellConfig,
 							name,
 							reason: effectiveReason,
 							mode: effectiveMode,
@@ -1050,6 +1067,7 @@ export default function interactiveShellExtension(pi: ExtensionAPI) {
 					new InteractiveShellOverlay(tui, theme, {
 						command: launchCommand,
 						cwd: effectiveCwd,
+						shellConfig,
 						name,
 						reason: effectiveReason,
 						mode,

--- a/overlay-component.ts
+++ b/overlay-component.ts
@@ -131,9 +131,13 @@ export class InteractiveShellOverlay implements Component, Focusable {
 			this.session.setEventHandlers(ptyEvents);
 			this.session.resize(cols, rows);
 		} else {
+			if (!options.shellConfig) {
+				throw new Error("A resolved Pi shell configuration is required before starting a PTY session.");
+			}
 			this.session = new PtyTerminalSession(
 				{
 					command: options.command,
+					shellConfig: options.shellConfig,
 					cwd: options.cwd,
 					cols,
 					rows,

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "key-encoding.ts",
     "overlay-component.ts",
     "pty-session.ts",
+    "shell-resolution.ts",
     "reattach-overlay.ts",
     "session-manager.ts",
     "tool-schema.ts",

--- a/pty-session.ts
+++ b/pty-session.ts
@@ -9,6 +9,7 @@ import {
 	buildPrimaryDeviceAttributesResponse,
 	splitAroundDeviceQueries,
 } from "./pty-protocol.ts";
+import type { ResolvedShellConfig } from "./shell-resolution.ts";
 
 const Terminal = xterm.Terminal;
 
@@ -109,7 +110,7 @@ function normalizePaletteColor(mode: "default" | "palette" | "rgb", value: numbe
 
 export interface PtySessionOptions {
 	command: string;
-	shell?: string;
+	shellConfig: ResolvedShellConfig;
 	cwd?: string;
 	env?: Record<string, string | undefined>;
 	cols?: number;
@@ -169,8 +170,13 @@ export class PtyTerminalSession {
 	}
 
 	constructor(options: PtySessionOptions, events: PtySessionEvents = {}) {
+		if (!options.shellConfig) {
+			throw new Error("A resolved Pi shell configuration is required before starting a PTY session.");
+		}
+
 		const {
 			command,
+			shellConfig,
 			cwd = process.cwd(),
 			env,
 			cols = 80,
@@ -188,12 +194,7 @@ export class PtyTerminalSession {
 			this.xterm.loadAddon(this.serializer);
 		}
 
-		const shell =
-			options.shell ??
-			(process.platform === "win32"
-				? process.env.COMSPEC || "cmd.exe"
-				: process.env.SHELL || "/bin/sh");
-		const shellArgs = process.platform === "win32" ? ["/c", command] : ["-c", command];
+		const shellArgs = [...shellConfig.args, command];
 
 		const mergedEnvRaw = env ? { ...process.env, ...env } : { ...process.env };
 		if (!mergedEnvRaw.TERM) mergedEnvRaw.TERM = "xterm-256color";
@@ -202,7 +203,7 @@ export class PtyTerminalSession {
 			if (value !== undefined) mergedEnv[key] = value;
 		}
 
-		this.ptyProcess = spawn(shell, shellArgs, {
+		this.ptyProcess = spawn(shellConfig.shell, shellArgs, {
 			name: "xterm-256color",
 			cols,
 			rows,

--- a/shell-resolution.ts
+++ b/shell-resolution.ts
@@ -13,7 +13,6 @@ import {
 export interface ResolvedShellConfig {
 	readonly shell: string;
 	readonly args: readonly string[];
-	readonly commandTransport: "argv";
 }
 
 /**
@@ -40,6 +39,5 @@ export function resolvePiShell(projectCwd: string, projectTrusted: boolean): Res
 	return Object.freeze({
 		shell: shellConfig.shell,
 		args: Object.freeze([...shellConfig.args]),
-		commandTransport: "argv" as const,
 	});
 }

--- a/shell-resolution.ts
+++ b/shell-resolution.ts
@@ -1,0 +1,45 @@
+import {
+	getAgentDir,
+	getShellConfig,
+	SettingsManager,
+} from "@earendil-works/pi-coding-agent";
+
+/**
+ * Shell configuration resolved once at a new-session launch boundary.
+ *
+ * Interactive PTYs append their command as an argv argument, so stdin-only
+ * shell transports are intentionally rejected by resolvePiShell().
+ */
+export interface ResolvedShellConfig {
+	readonly shell: string;
+	readonly args: readonly string[];
+	readonly commandTransport: "argv";
+}
+
+/**
+ * Resolve the same trusted Bash selection Pi uses for its shell tool.
+ *
+ * `projectCwd` must be Pi's trusted context project, not an arbitrary command
+ * cwd supplied by the caller. The settings manager reads settings once here;
+ * callers should pass the returned immutable config through the launch path.
+ */
+export function resolvePiShell(projectCwd: string, projectTrusted: boolean): ResolvedShellConfig {
+	const settingsManager = SettingsManager.create(projectCwd, getAgentDir(), { projectTrusted });
+	const shellConfig = getShellConfig(settingsManager.getShellPath());
+
+	if (shellConfig.commandTransport !== undefined && shellConfig.commandTransport !== "argv") {
+		throw new Error(
+			`Pi selected "${shellConfig.shell}", which requires stdin command transport. `
+			+ "interactive_shell PTYs require argv command transport; configure shellPath to a Git Bash executable instead.",
+		);
+	}
+	if (!shellConfig.shell || shellConfig.args.length === 0) {
+		throw new Error("Pi returned an invalid shell configuration: a shell executable and argv are required.");
+	}
+
+	return Object.freeze({
+		shell: shellConfig.shell,
+		args: Object.freeze([...shellConfig.args]),
+		commandTransport: "argv" as const,
+	});
+}

--- a/spawn.ts
+++ b/spawn.ts
@@ -292,9 +292,9 @@ function shellQuoteIfNeeded(value: string): string {
 }
 
 function shellQuote(value: string): string {
-	if (process.platform === "win32") {
-		return `"${value.replace(/"/g, '""')}"`;
-	}
+	// All generated commands run through Pi's Bash selection, including on
+	// Windows. Single-quoted Bash arguments preserve literal `$`, backticks,
+	// backslashes, and whitespace; close/reopen around embedded single quotes.
 	return `'${value.replace(/'/g, `'\\''`)}'`;
 }
 

--- a/tests/config-and-docs.test.ts
+++ b/tests/config-and-docs.test.ts
@@ -138,6 +138,14 @@ describe("config + docs parity", () => {
 		expect(readme).toContain(`"handsFreeQuietThreshold": ${defaults.handsFreeQuietThreshold}`);
 		expect(readme).toContain(`"autoExitGracePeriod": ${defaults.autoExitGracePeriod}`);
 		expect(readme).toContain(`Dispatch defaults \`autoExitOnQuiet: true\` — the session gets a 15s startup grace period`);
+		expect(readme).toContain("same Bash resolver as Pi");
+		expect(readme).toContain("Pi discovers Git Bash in its standard install");
+		expect(readme).toContain("locations, then `bash.exe` on `PATH`");
+		expect(readme).toContain('"shellPath": "C:/Program Files/Git/bin/bash.exe"');
+		expect(readme).toContain("trusted project's `shellPath`");
+		expect(readme).toContain("overrides the global setting");
+		expect(readme).toContain("legacy WSL `bash.exe` uses");
+		expect(readme).toContain("stdin-only command transport");
 		expect(readme).toContain('completionReason: "auto-close-quiet"');
 		expect(readme).toContain("this is not a terminal command verdict.");
 		expect(readme).toContain("provider-agnostic watch-until-terminal pattern");

--- a/tests/dispatch-background-recovery.test.ts
+++ b/tests/dispatch-background-recovery.test.ts
@@ -12,6 +12,8 @@ async function setupHarness() {
 	vi.resetModules();
 	vi.doMock("@earendil-works/pi-coding-agent", () => ({
 		getAgentDir: () => "/tmp/pi-agent",
+		getShellConfig: () => ({ shell: "/bin/bash", args: ["-c"] }),
+		SettingsManager: { create: () => ({ getShellPath: () => undefined }) },
 	}));
 	vi.doMock("@earendil-works/pi-tui", () => ({
 		isKeyRelease: () => false,

--- a/tests/monitor-mode.test.ts
+++ b/tests/monitor-mode.test.ts
@@ -321,7 +321,6 @@ describe("monitor mode", () => {
 		expect(result.isError).not.toBe(true);
 		expect(harness.getLaunchedCommand()).toContain("while true; do");
 		expect(harness.getLaunchedCommand()).toContain("echo health");
-		expect(harness.getLaunchedCommand()).not.toContain("for /L");
 	});
 
 	it("supports regex capture thresholds in triggers", async () => {

--- a/tests/monitor-mode.test.ts
+++ b/tests/monitor-mode.test.ts
@@ -12,9 +12,17 @@ type MonitorOptionsCapture = {
 	onMonitorEvent?: (event: unknown) => void | Promise<void>;
 } | null;
 
+type DetectorLaunchCapture = {
+	shell: string;
+	args: string[];
+	cwd?: string;
+	stdin: string;
+} | null;
+
 async function setupHarness(options: { detectorStdout?: string } = {}) {
 	let toolDef: any;
 	let monitorOptions: MonitorOptionsCapture = null;
+	let detectorLaunch: DetectorLaunchCapture = null;
 	let launchedCommand: string | undefined;
 	let monitorCompleteCallback: ((info: unknown) => void) | undefined;
 	let activeSession: unknown;
@@ -23,9 +31,12 @@ async function setupHarness(options: { detectorStdout?: string } = {}) {
 	vi.resetModules();
 	vi.doMock("@earendil-works/pi-coding-agent", () => ({
 		getAgentDir: () => "/tmp/pi-agent",
+		getShellConfig: () => ({ shell: "/bin/bash", args: ["-c"] }),
+		SettingsManager: { create: () => ({ getShellPath: () => undefined }) },
 	}));
 	vi.doMock("node:child_process", () => ({
-		spawn: vi.fn(() => {
+		spawn: vi.fn((shell: string, args: string[], spawnOptions: { cwd?: string }) => {
+			let stdin = "";
 			const child = new EventEmitter() as EventEmitter & {
 				stdout: EventEmitter & { setEncoding: (encoding: string) => void };
 				stderr: EventEmitter & { setEncoding: (encoding: string) => void };
@@ -34,7 +45,15 @@ async function setupHarness(options: { detectorStdout?: string } = {}) {
 			};
 			child.stdout = Object.assign(new EventEmitter(), { setEncoding: vi.fn() });
 			child.stderr = Object.assign(new EventEmitter(), { setEncoding: vi.fn() });
-			child.stdin = { write: vi.fn(), end: vi.fn() };
+			const writeStdin = vi.fn((data: string) => {
+				stdin += data;
+				if (detectorLaunch) detectorLaunch.stdin = stdin;
+			});
+			child.stdin = {
+				write: writeStdin,
+				end: vi.fn(),
+			};
+			detectorLaunch = { shell, args: [...args], cwd: spawnOptions.cwd, stdin };
 			child.kill = vi.fn();
 			process.nextTick(() => {
 				child.stdout.emit("data", options.detectorStdout ?? "");
@@ -167,6 +186,7 @@ async function setupHarness(options: { detectorStdout?: string } = {}) {
 	return {
 		toolDef,
 		getMonitorOptions: () => monitorOptions,
+		getDetectorLaunch: () => detectorLaunch,
 		getLaunchedCommand: () => launchedCommand,
 		getMonitorCompleteCallback: () => monitorCompleteCallback,
 		setActiveSession: (session: unknown) => { activeSession = session; },
@@ -301,6 +321,7 @@ describe("monitor mode", () => {
 		expect(result.isError).not.toBe(true);
 		expect(harness.getLaunchedCommand()).toContain("while true; do");
 		expect(harness.getLaunchedCommand()).toContain("echo health");
+		expect(harness.getLaunchedCommand()).not.toContain("for /L");
 	});
 
 	it("supports regex capture thresholds in triggers", async () => {
@@ -394,6 +415,30 @@ describe("monitor mode", () => {
 		expect(harness.getLaunchedCommand()).toContain("uploads");
 	});
 
+	it("quotes Bash-sensitive file-watch paths literally", async () => {
+		const harness = await setupHarness();
+		const watchPath = "$HOME/it's `pwd`";
+		const result = await harness.toolDef.execute("call-1", {
+			mode: "monitor",
+			monitor: {
+				strategy: "file-watch",
+				fileWatch: { path: watchPath, events: ["change"] },
+				triggers: [{ id: "changed", literal: "CHANGE" }],
+			},
+		}, undefined, undefined, {
+			hasUI: false,
+			cwd: "/tmp/project",
+			ui: {},
+			sessionManager: { getSessionFile: () => "/tmp/project/session.jsonl" },
+		} as any);
+
+		expect(result.isError).not.toBe(true);
+		const launchedCommand = harness.getLaunchedCommand() ?? "";
+		expect(launchedCommand).toContain("$HOME/it");
+		expect(launchedCommand).toContain("`pwd`");
+		expect(launchedCommand).toContain("'\\''");
+	});
+
 	it("returns monitor status summaries", async () => {
 		const harness = await setupHarness();
 		const started = await harness.toolDef.execute("call-1", {
@@ -480,6 +525,47 @@ describe("monitor mode", () => {
 		expect(filtered.details.events[0]?.triggerId).toBe("warn");
 		expect(filtered.details.sinceEventId).toBe(1);
 		expect(filtered.details.triggerId).toBe("warn");
+	});
+
+	it("runs detector commands through the launch-resolved Bash and keeps JSON on stdin", async () => {
+		const harness = await setupHarness();
+		await harness.toolDef.execute("call-1", {
+			command: "npm test --watch",
+			mode: "monitor",
+			monitor: {
+				strategy: "stream",
+				triggers: [{ id: "fail", literal: "FAIL" }],
+				detector: { detectorCommand: "cat >/dev/null" },
+			},
+		}, undefined, undefined, {
+			hasUI: false,
+			cwd: "/tmp/project",
+			ui: {},
+			sessionManager: { getSessionFile: () => "/tmp/project/session.jsonl" },
+		} as any);
+
+		harness.getMonitorOptions()?.onMonitorEvent?.({
+			strategy: "stream",
+			triggerId: "fail",
+			eventType: "fail",
+			matchedText: "FAIL",
+			lineOrDiff: "FAIL first",
+			stream: "pty",
+		});
+		await new Promise((resolve) => setTimeout(resolve, 20));
+
+		const launch = harness.getDetectorLaunch();
+		expect(launch).toMatchObject({
+			shell: "/bin/bash",
+			args: ["-c", "cat >/dev/null"],
+			cwd: "/tmp/project",
+		});
+		expect(JSON.parse(launch?.stdin ?? "")).toMatchObject({
+			sessionId: "monitor-1",
+			triggerId: "fail",
+			matchedText: "FAIL",
+			lineOrDiff: "FAIL first",
+		});
 	});
 
 	it("rejects detectorCommand decisions with invalid shapes", async () => {

--- a/tests/monitor-mode.test.ts
+++ b/tests/monitor-mode.test.ts
@@ -26,7 +26,11 @@ async function setupHarness(options: { detectorStdout?: string } = {}) {
 	let launchedCommand: string | undefined;
 	let monitorCompleteCallback: ((info: unknown) => void) | undefined;
 	let activeSession: unknown;
-	const sendMessage = vi.fn();
+	let resolveMonitorNotification!: () => void;
+	const monitorNotification = new Promise<void>((resolve) => { resolveMonitorNotification = resolve; });
+	const sendMessage = vi.fn((message: { customType?: string }) => {
+		if (message.customType === "interactive-shell-monitor-event") resolveMonitorNotification();
+	});
 
 	vi.resetModules();
 	vi.doMock("@earendil-works/pi-coding-agent", () => ({
@@ -189,6 +193,7 @@ async function setupHarness(options: { detectorStdout?: string } = {}) {
 		getDetectorLaunch: () => detectorLaunch,
 		getLaunchedCommand: () => launchedCommand,
 		getMonitorCompleteCallback: () => monitorCompleteCallback,
+		waitForMonitorNotification: () => monitorNotification,
 		setActiveSession: (session: unknown) => { activeSession = session; },
 		sendMessage,
 	};
@@ -551,7 +556,7 @@ describe("monitor mode", () => {
 			lineOrDiff: "FAIL first",
 			stream: "pty",
 		});
-		await new Promise((resolve) => setTimeout(resolve, 20));
+		await harness.waitForMonitorNotification();
 
 		const launch = harness.getDetectorLaunch();
 		expect(launch).toMatchObject({

--- a/tests/pty-session.test.ts
+++ b/tests/pty-session.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it } from "vitest";
 import { PtyTerminalSession } from "../pty-session.ts";
+import { resolvePiShell } from "../shell-resolution.ts";
 
 const sessions: PtyTerminalSession[] = [];
 
@@ -27,8 +28,25 @@ afterEach(() => {
 });
 
 describe("PtyTerminalSession cleanup", () => {
+	it("executes commands through the resolved Pi shell argv", async () => {
+		const output: string[] = [];
+		const session = new PtyTerminalSession(
+			{ command: "printf 'pi-shell-argv-ok\\n'", shellConfig: resolvePiShell(process.cwd(), true) },
+			{ onData: (data) => output.push(data) },
+		);
+		sessions.push(session);
+
+		const deadline = Date.now() + 1000;
+		while (!session.exited && Date.now() < deadline) {
+			await new Promise((resolve) => setTimeout(resolve, 20));
+		}
+
+		expect(session.exited).toBe(true);
+		expect(output.join("")).toContain("pi-shell-argv-ok");
+	});
+
 	it("kill forcefully terminates an interactive shell", async () => {
-		const session = new PtyTerminalSession({ command: "bash -i" });
+		const session = new PtyTerminalSession({ command: "bash -i", shellConfig: resolvePiShell(process.cwd(), true) });
 		sessions.push(session);
 		const pid = session.pid;
 		await new Promise((resolve) => setTimeout(resolve, 100));

--- a/tests/pty-session.test.ts
+++ b/tests/pty-session.test.ts
@@ -1,6 +1,12 @@
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { PtyTerminalSession } from "../pty-session.ts";
 import { resolvePiShell } from "../shell-resolution.ts";
+
+vi.mock("@earendil-works/pi-coding-agent", async () => ({
+	...(await vi.importActual<typeof import("@earendil-works/pi-coding-agent")>("@earendil-works/pi-coding-agent")),
+	getAgentDir: () => "/tmp/pi-agent",
+	SettingsManager: { create: () => ({ getShellPath: () => undefined }) },
+}));
 
 const sessions: PtyTerminalSession[] = [];
 
@@ -29,20 +35,29 @@ afterEach(() => {
 
 describe("PtyTerminalSession cleanup", () => {
 	it("executes commands through the resolved Pi shell argv", async () => {
+		if (process.platform === "win32") return;
+		const previousShell = process.env.SHELL;
+		process.env.SHELL = "/bin/sh";
 		const output: string[] = [];
-		const session = new PtyTerminalSession(
-			{ command: "printf 'pi-shell-argv-ok\\n'", shellConfig: resolvePiShell(process.cwd(), true) },
-			{ onData: (data) => output.push(data) },
-		);
-		sessions.push(session);
+		try {
+			let resolveExit!: () => void;
+			const exited = new Promise<void>((resolve) => { resolveExit = resolve; });
+			const session = new PtyTerminalSession(
+				{
+					command: `if [[ "$BASH" == *bash ]]; then printf 'pi-bash-selection-ok\\n'; fi`,
+					shellConfig: resolvePiShell(process.cwd(), true),
+				},
+				{ onData: (data) => output.push(data), onExit: () => resolveExit() },
+			);
+			sessions.push(session);
 
-		const deadline = Date.now() + 1000;
-		while (!session.exited && Date.now() < deadline) {
-			await new Promise((resolve) => setTimeout(resolve, 20));
+			await exited;
+			expect(session.exited).toBe(true);
+			expect(output.join("")).toContain("pi-bash-selection-ok");
+		} finally {
+			if (previousShell === undefined) delete process.env.SHELL;
+			else process.env.SHELL = previousShell;
 		}
-
-		expect(session.exited).toBe(true);
-		expect(output.join("")).toContain("pi-shell-argv-ok");
 	});
 
 	it("kill forcefully terminates an interactive shell", async () => {

--- a/tests/shell-resolution.test.ts
+++ b/tests/shell-resolution.test.ts
@@ -35,10 +35,8 @@ describe("trusted Pi shell resolution", () => {
 		const trusted = resolvePiShell(project, true);
 		const untrusted = resolvePiShell(project, false);
 
-		expect(trusted).toMatchObject({ shell: "/bin/bash", args: ["-c"], commandTransport: "argv" });
-		expect(untrusted).toMatchObject({ shell: "/bin/sh", args: ["-c"], commandTransport: "argv" });
-		expect(Object.isFrozen(trusted)).toBe(true);
-		expect(Object.isFrozen(trusted.args)).toBe(true);
+		expect(trusted).toMatchObject({ shell: "/bin/bash", args: ["-c"] });
+		expect(untrusted).toMatchObject({ shell: "/bin/sh", args: ["-c"] });
 	});
 
 	it("rejects Pi shell configurations that require stdin command transport", async () => {

--- a/tests/shell-resolution.test.ts
+++ b/tests/shell-resolution.test.ts
@@ -1,0 +1,57 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+const tempRoots: string[] = [];
+
+afterEach(() => {
+	for (const root of tempRoots.splice(0)) {
+		rmSync(root, { recursive: true, force: true });
+	}
+	vi.doUnmock("@earendil-works/pi-coding-agent");
+});
+
+describe("trusted Pi shell resolution", () => {
+	it("uses project shellPath only when the Pi context trusts the project", async () => {
+		if (process.platform === "win32") return;
+
+		const root = mkdtempSync(join(tmpdir(), "interactive-shell-resolution-"));
+		tempRoots.push(root);
+		const agentDir = join(root, "agent");
+		const project = join(root, "project");
+		mkdirSync(agentDir, { recursive: true });
+		mkdirSync(join(project, ".pi"), { recursive: true });
+		writeFileSync(join(agentDir, "settings.json"), JSON.stringify({ shellPath: "/bin/sh" }));
+		writeFileSync(join(project, ".pi", "settings.json"), JSON.stringify({ shellPath: "/bin/bash" }));
+
+		vi.resetModules();
+		vi.doMock("@earendil-works/pi-coding-agent", async () => ({
+			...(await vi.importActual<typeof import("@earendil-works/pi-coding-agent")>("@earendil-works/pi-coding-agent")),
+			getAgentDir: () => agentDir,
+		}));
+		const { resolvePiShell } = await import("../shell-resolution.ts");
+
+		const trusted = resolvePiShell(project, true);
+		const untrusted = resolvePiShell(project, false);
+
+		expect(trusted).toMatchObject({ shell: "/bin/bash", args: ["-c"], commandTransport: "argv" });
+		expect(untrusted).toMatchObject({ shell: "/bin/sh", args: ["-c"], commandTransport: "argv" });
+		expect(Object.isFrozen(trusted)).toBe(true);
+		expect(Object.isFrozen(trusted.args)).toBe(true);
+	});
+
+	it("rejects Pi shell configurations that require stdin command transport", async () => {
+		vi.resetModules();
+		vi.doMock("@earendil-works/pi-coding-agent", () => ({
+			getAgentDir: () => "/tmp/pi-agent",
+			SettingsManager: { create: () => ({ getShellPath: () => "legacy-wsl-bash" }) },
+			getShellConfig: () => ({ shell: "legacy-wsl-bash", args: ["-s"], commandTransport: "stdin" }),
+		}));
+		const { resolvePiShell } = await import("../shell-resolution.ts");
+
+		expect(() => resolvePiShell("/tmp/project", true)).toThrow(
+			/which requires stdin command transport.*configure shellPath to a Git Bash executable/,
+		);
+	});
+});

--- a/tests/spawn-command.test.ts
+++ b/tests/spawn-command.test.ts
@@ -21,6 +21,8 @@ async function setupExtensionHarness(configOverrides: SpawnConfigOverrides = {})
 	vi.resetModules();
 	vi.doMock("@earendil-works/pi-coding-agent", () => ({
 		getAgentDir: () => "/tmp/pi-agent",
+		getShellConfig: () => ({ shell: "/bin/bash", args: ["-c"] }),
+		SettingsManager: { create: () => ({ getShellPath: () => undefined }) },
 	}));
 	vi.doMock("@earendil-works/pi-tui", () => ({
 		matchesKey: () => false,
@@ -131,6 +133,7 @@ async function setupExtensionHarness(configOverrides: SpawnConfigOverrides = {})
 		ui: { notify, custom },
 		cwd: "/tmp/project",
 		hasUI: true,
+		isProjectTrusted: () => true,
 		sessionManager: {
 			getSessionFile: () => "/tmp/project/session.jsonl",
 		},
@@ -217,9 +220,7 @@ describe("/spawn command, shortcut, and tool spawn", () => {
 		expect(spawn).toBeDefined();
 
 		await spawn!.handler("pi fork", harness.ctx as any);
-		const expectedForkArg = process.platform === "win32"
-			? '"/tmp/project/it\'s session.jsonl"'
-			: "'/tmp/project/it'\\''s session.jsonl'";
+		const expectedForkArg = "'/tmp/project/it'\\''s session.jsonl'";
 		expect(harness.getLastOverlayOptions()).toMatchObject({
 			command: `pi --fork ${expectedForkArg}`,
 			reason: "spawn pi (fork current session)",

--- a/tests/spawn.test.ts
+++ b/tests/spawn.test.ts
@@ -191,6 +191,23 @@ describe("spawn helpers", () => {
 		});
 	});
 
+	it("preserves Bash-sensitive prompt contents as a literal argument", async () => {
+		const { resolveSpawn } = await import("../spawn.ts");
+		const prompt = "literal $HOME `pwd` and it's";
+		const result = resolveSpawn(config, "/tmp/project", { agent: "claude", prompt }, () => "/tmp/project/session.jsonl");
+
+		expect(result).toEqual({
+			ok: true,
+			spawn: {
+				agent: "claude",
+				mode: "fresh",
+				command: "claude 'literal $HOME `pwd` and it'\\''s'",
+				cwd: "/tmp/project",
+				reason: "spawn claude (fresh session)",
+			},
+		});
+	});
+
 	it("normalizes serialized spawn fields without erasing standalone requests", async () => {
 		const { isEmptySpawnPlaceholder, normalizeSpawnRequest } = await import("../spawn.ts");
 		expect(normalizeSpawnRequest(undefined)).toBeUndefined();

--- a/types.ts
+++ b/types.ts
@@ -2,6 +2,8 @@
  * Shared types and interfaces for the interactive shell extension.
  */
 
+import type { ResolvedShellConfig } from "./shell-resolution.ts";
+
 export type DispatchCompletionReason = "exited" | "timed-out" | "killed" | "auto-close-quiet";
 
 export interface InteractiveShellResult {
@@ -131,6 +133,8 @@ export interface MonitorSessionState {
 export interface InteractiveShellOptions {
 	command: string;
 	cwd?: string;
+	/** Resolved once for a new launch; omitted when attaching to an existing PTY. */
+	shellConfig?: ResolvedShellConfig;
 	name?: string;
 	reason?: string;
 	/** Original session start time in ms since epoch, preserved across background/reattach transitions. */


### PR DESCRIPTION
## Summary
- Use Pi's Bash resolver and trusted `shellPath` settings for new interactive sessions on every platform.
- Quote generated spawn and monitor commands for Bash, and reuse the launch shell for detector commands while keeping candidate JSON on stdin.
- Document the Unix default change and Windows Git Bash discovery. Legacy WSL stdin-only launchers fail early with guidance to select Git Bash.

The maintainer approved changing Unix defaults from `$SHELL` to Pi's Bash selection. Existing attached sessions keep their original process. Shell settings are resolved at launch, not per monitor event.

## Validation
- Typecheck and full test suite passed on macOS.
- Focused coverage for trusted/untrusted settings, PTY output, generated arguments and detector stdin.
- Fresh read-only review: no issues found. Retained implementation challenge and simplification completed.
- Package dry run includes the new resolver.

Native Windows execution was not available locally.

Thanks to [@lazyst](https://github.com/lazyst) for the report and investigation.

Fixes #51
